### PR TITLE
[BD-27] Add Discussion Topic Support

### DIFF
--- a/src/cc2olx/olx.py
+++ b/src/cc2olx/olx.py
@@ -25,6 +25,7 @@ class OlxExport:
     VIDEO = "video"
     LTI = "lti"
     QTI = "qti"
+    DISCUSSION = "discussion"
 
     def __init__(self, cartridge):
         self.cartridge = cartridge
@@ -136,6 +137,9 @@ class OlxExport:
             qti_export = QtiExport(self.doc)
             nodes += qti_export.create_qti_node(details)
 
+        elif content_type == self.DISCUSSION:
+            nodes += self._create_discussion_node(details)
+
         else:
             raise OlxExportException("Content type \"{}\" is not supported.".format(content_type))
 
@@ -162,6 +166,16 @@ class OlxExport:
         node.setAttribute('modal_width', details['width'])
         node.setAttribute('xblock-family', 'xblock.v1')
         return node
+
+    def _create_discussion_node(self, details):
+        node = self.doc.createElement('discussion')
+        node.setAttribute('display_name', '')
+        node.setAttribute('discussion_category', details['title'])
+        node.setAttribute('discussion_target', details['title'])
+        html_node = self.doc.createElement("html")
+        txt = self.doc.createCDATASection(details["text"])
+        html_node.appendChild(txt)
+        return [html_node, node]
 
 
 def process_link(details):

--- a/tests/fixtures_data/imscc_file/discussion_topic.xml
+++ b/tests/fixtures_data/imscc_file/discussion_topic.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<topic xmlns="http://www.imsglobal.org/xsd/imsccv1p1/imsdt_v1p1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsccv1p1/imsdt_v1p1  http://www.imsglobal.org/profile/cc/ccv1p1/ccv1p1_imsdt_v1p1.xsd">
+  <title>Discussion Topic</title>
+  <text texttype="text/html">&lt;p style="text-align: center;"&gt;&lt;span style="color: #000080; font-size: 18pt;"&gt;Math Journal&lt;/span&gt;&lt;br&gt;Is 70 thousand written in standard form or&lt;br&gt;word form? Explain.&lt;/p&gt;</text>
+</topic>

--- a/tests/fixtures_data/imscc_file/discussion_topic_dependency.xml
+++ b/tests/fixtures_data/imscc_file/discussion_topic_dependency.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<topicMeta identifier="discussion_top_dependency" xmlns="http://canvas.instructure.com/xsd/cccv1p0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://canvas.instructure.com/xsd/cccv1p0 https://canvas.instructure.com/xsd/cccv1p0.xsd">
+  <topic_id>1</topic_id>
+  <title>Discussion Topic</title>
+  <delayed_post_at>2020-08-26T06:00:00</delayed_post_at>
+  <lock_at>2020-08-27T05:59:59</lock_at>
+  <position/>
+  <type>topic</type>
+  <discussion_type>side_comment</discussion_type>
+  <has_group_category>false</has_group_category>
+  <workflow_state>unpublished</workflow_state>
+  <module_locked>false</module_locked>
+  <allow_rating>false</allow_rating>
+  <only_graders_can_rate>false</only_graders_can_rate>
+  <sort_by_rating>false</sort_by_rating>
+  <todo_date/>
+</topicMeta>

--- a/tests/fixtures_data/imscc_file/imsmanifest.xml
+++ b/tests/fixtures_data/imscc_file/imsmanifest.xml
@@ -45,6 +45,9 @@
                     <item identifier="qti" identifierref="resource_4_qti">
                         <title>QTI</title>
                     </item>
+                    <item identifier="discussion_topic_item" identifierref="discussion_topic">
+                        <title>Discussion</title>
+                    </item>
                 </item>
             </item>
         </organization>
@@ -74,6 +77,13 @@
         <resource identifier="resource_5_qti_dependency" type="associatedcontent/imscc_xmlv1p1/learning-application-resource" href="resource_4_qti/assessment_meta.xml">
             <file href="resource_4_qti/assessment_meta.xml"/>
             <file href="non_cc_assessments/resource_4_qti.xml.qti"/>
+        </resource>
+        <resource identifier="discussion_topic" type="imsdt_xmlv1p1">
+            <file href="discussion_topic.xml" />
+            <dependency identifierref="discussion_topic_dependency" />
+        </resource>
+        <resource identifier="discussion_topic_dependency" type="associatedcontent/imscc_xmlv1p1/learning-application-resource" href="g152c146947dcdc992d8750cf2c7690ae.xml">
+            <file href="discussion_topic_dependency.xml"/>
         </resource>
     </resources>
 </manifest>

--- a/tests/fixtures_data/studio_course_xml/course.xml
+++ b/tests/fixtures_data/studio_course_xml/course.xml
@@ -88,6 +88,10 @@
                     </rubric>
                 </openassessment>
             </vertical>
+            <vertical display_name="Discussion">
+                <html display_name="Discussion"><![CDATA[<p style="text-align: center;"><span style="color: #000080; font-size: 18pt;">Math Journal</span><br>Is 70 thousand written in standard form or<br>word form? Explain.</p>]]></html>
+                <discussion display_name="Discussion" discussion_category="Discussion Topic" discussion_target="Discussion Topic"/>
+            </vertical>
         </sequential>
     </chapter>
 </course>

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -36,7 +36,7 @@ def test_load_manifest_extracted(imscc_file, settings, temp_workspace_dir):
         "name": "IMS Common Cartridge", "version": cartridge_version
     }
 
-    assert len(cartridge.resources) == 5
+    assert len(cartridge.resources) == 7
     assert len(cartridge.resources[0]["children"]) == 6
     assert isinstance(cartridge.resources[0]["children"][0], ResourceFile)
 
@@ -87,6 +87,18 @@ def test_cartridge_normalize(imscc_file, settings):
                                 "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
                                 "identifierref": None,
                                 "title": "QTI"
+                            },
+                            {
+                                "children": [
+                                    {
+                                        "identifier": "discussion_topic_item",
+                                        "identifierref": "discussion_topic",
+                                        "title": "Discussion",
+                                    }
+                                ],
+                                "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                                "identifierref": None,
+                                "title": "Discussion",
                             },
                         ],
                         "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",


### PR DESCRIPTION
This PR adds support for converting Common Cartridge [Discussion Topic Content Types](https://www.imsglobal.org/cc/ccv1p1/imscc_profilev1p1-Implementation.html#toc-43) to [OLX Discussion Component](https://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/components/discussion-components.html).

**JIRA tickets**: 
- https://tasks.opencraft.com/browse/BB-2894

~~**Discussions**:~~ 

**Dependencies**: None

~~**Screenshots**:~~

~~**Sandbox URL**:~~

**Merge deadline**: None

**Testing instructions**:

1. Get ``imscc`` file which contains discussion topic
2. Convert using ``cc2olx``
3. Check if the output contains olx ``discussion`` component with contents from discussion topic
4. Check if the output contains ``HTML Block`` component with discussion description
5. Import generated output to edX studio.
6. Check LMS if discussion created with a description on top.

**Author notes and concerns**:

1. There is no equivalent tag in olx for ``dependency`` items in the common cartridge discussion topic. Those are mentioned as -
> The Resource object may contain Dependency objects which reference Resource objects with Type ‘webcontent’ and/or ‘associatedcontent/imscc_xmlv1p1/learning-application-resource’.

**Reviewers**
- [x] @kaizoku
- [ ] edX reviewer[s] TBD

~~**Settings**~~
