### PR TITLE
hide github annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,3 +11,6 @@ coverage:
         target: 80%
 
 comment: false
+
+github_checks:
+    annotations: false


### PR DESCRIPTION
This PR will make github stop displaying codecov annotations inline in the code diffs.  Also it enables targets that were previously defined in coverage.yml, but were not in effect because they need to be in codecov.yml.