### PR TITLE
constrain importlib_metadata

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,3 +10,6 @@
 
 # Version 2 requires Python 3.5
 zipp==1.2.0
+
+# Needed as long as tox constrains this to <2
+importlib_metadata<2


### PR DESCRIPTION
tox constrains this requirement to <2 but comes in later in the requirement file chain so this is required to resolve upgrade issues