### PR TITLE
[BD-27] Improve Logging and Output for cc2olx converter

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,10 @@ omit =
     *admin.py
     *static*
     *templates*
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+    # Custom
+    logger\.[a-zA-Z]+\(.*\)

--- a/src/cc2olx/filesystem.py
+++ b/src/cc2olx/filesystem.py
@@ -14,6 +14,7 @@ def create_directory(directory_path):
 
 
 def get_xml_tree(path_src):
+    logger.info('Loading file %s', path_src)
     try:
         tree = ElementTree.parse(str(path_src))
         return tree
@@ -53,7 +54,8 @@ def add_in_tar_gz(archive_name, inputs):
             try:
                 archive.add(file, alternative_name)
             except FileNotFoundError:
-                print("{} was not found. Skipping".format(str(file)))
-                pass
+                logger.error(
+                    "%s was not found. Skipping", str(file), exc_info=True
+                )
 
     return archive_name

--- a/src/cc2olx/main.py
+++ b/src/cc2olx/main.py
@@ -1,3 +1,4 @@
+import logging
 import shutil
 import sys
 import tempfile
@@ -40,6 +41,10 @@ def main():
     settings = collect_settings(parsed_args)
 
     workspace = settings["workspace"]
+
+    # setup logger
+    logging_config = settings["logging_config"]
+    logging.basicConfig(level=logging_config["level"], format=logging_config["format"])
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         temp_workspace = Path(tmpdirname) / workspace.stem

--- a/src/cc2olx/models.py
+++ b/src/cc2olx/models.py
@@ -1,3 +1,4 @@
+import logging
 import os.path
 import re
 from textwrap import dedent
@@ -5,6 +6,8 @@ import zipfile
 
 from cc2olx import filesystem
 from cc2olx.qti import QtiParser
+
+logger = logging.getLogger()
 
 MANIFEST = 'imsmanifest.xml'
 DIFFUSE_SHALLOW_SECTIONS = False
@@ -254,7 +257,7 @@ class Cartridge:
         """
         res = self.resources_by_id.get(identifier)
         if res is None:
-            print("*** Missing resource: {}".format(identifier))
+            logger.info("Missing resource: %s", identifier)
             return None, None
 
         res_type = res["type"]
@@ -265,15 +268,11 @@ class Cartridge:
                     with open(str(res_filename)) as res_file:
                         html = res_file.read()
                 except:  # noqa: E722
-                    print(
-                        "Failure reading {!r} from id {}".format(
-                            res_filename, identifier
-                        )
-                    )
+                    logger.error("Failure reading %s from id %s", res_filename, identifier)  # noqa: E722
                     raise
                 return "html", {"html": html}
             else:
-                print("*** Skipping webcontent: {}".format(res_filename))
+                logger.info("Skipping webcontent: %s", res_filename)
                 return None, None
         elif res_type == "imswl_xmlv1p1":
             tree = filesystem.get_xml_tree(self._res_filename(res["children"][0].href))
@@ -296,7 +295,7 @@ class Cartridge:
             text = "Unimported content: type = {!r}".format(res_type)
             if "href" in res:
                 text += ", href = {!r}".format(res["href"])
-            print("***", text)
+            logger.info("%s", text)
             return "html", {"html": text}
 
     def load_manifest_extracted(self):
@@ -545,7 +544,7 @@ class Cartridge:
             elif tag == 'metadata':
                 child_data = self._parse_resource_metadata(child)
             else:
-                print('UNSUPPORTED RESOURCE TYPE', tag)
+                logger.info('Unsupported Resource Type %s', tag)
                 continue
             if child_data:
                 children.append(child_data)

--- a/src/cc2olx/qti.py
+++ b/src/cc2olx/qti.py
@@ -1,3 +1,4 @@
+import logging
 import urllib.parse
 import xml.dom.minidom
 from collections import OrderedDict
@@ -8,6 +9,8 @@ from lxml import etree, html
 from cc2olx import filesystem
 
 from .utils import element_builder
+
+logger = logging.getLogger()
 
 # problem types
 MULTIPLE_CHOICE = "cc.multiple_choice.v0p1"
@@ -326,7 +329,9 @@ class QtiParser:
                 data.update(parse_problem(problem))
                 parsed_problems.append(data)
             except NotImplementedError:
-                print("'{}' profile is not supported yet.".format(cc_profile))
+                logger.info("Problem with ID %s can\'t be converted.", problem.attrib.get('ident'))
+                logger.info("    Profile %s is not supported.", cc_profile)
+                logger.info("    At file %s.", self.resource_filename)
 
         return parsed_problems
 

--- a/src/cc2olx/utils.py
+++ b/src/cc2olx/utils.py
@@ -1,4 +1,7 @@
 """ Utility functions for cc2olx"""
+import logging
+
+logger = logging.getLogger()
 
 
 def element_builder(xml_doc):


### PR DESCRIPTION
This PR adds some improvement in the ``cc2olx`` logging output. 

**JIRA tickets**: https://tasks.opencraft.com/browse/BB-3071

**Discussions**: https://openedx.slack.com/archives/C015PT4M8AY/p1600812119005700

**Dependencies**: None

~~**Screenshots**:~~

~~**Sandbox URL**:~~

**Merge deadline**: "None" 

**Testing instructions**:

1. Find a Common Cartridge file that contains problem type that has not been implemented in ``cc2olx``.
2. Convert using ``cc2olx``.
3. Python ``logging`` module is used for log output instead of ``print`` statements.
4. Shows which file from ``imscc`` archive is currently being processed.

**Author notes and concerns**: N/A

**Reviewers**
- [x] @0x29a 
- [ ] edX reviewer[s] TBD

~~**Settings**~~