### PR TITLE
[BD-27] [TNL-7693][BB-3247]Fixed replacing of link from href attribute

### DIFF
--- a/src/cc2olx/olx.py
+++ b/src/cc2olx/olx.py
@@ -110,11 +110,22 @@ class OlxExport:
         return content_type, details
 
     def _process_static_links(self, html):
-        srcs = re.findall(r'src\s*=\s*"(.+?)"', html)
-        for src in srcs:
-            if 'IMS-CC-FILEBASE' in src:
-                new_src = urllib.parse.unquote(src).replace("$IMS-CC-FILEBASE$", "/static")
-                html = html.replace(src, new_src)
+        """
+        This function helps to convert the IMSCC FILEBASE path
+        to a normal static path.
+
+        Args:
+            html ([str]): HTML content of the file.
+
+        Returns:
+            [str]: Corrected HTML content of the file.
+        """
+        # Here the attributes that are tageted are href and src
+        srcs = re.findall(r'(src|href)\s*=\s*"(.+?)"', html)
+        for tag, link in srcs:
+            if 'IMS-CC-FILEBASE' in link:
+                new_src = urllib.parse.unquote(link).replace("$IMS-CC-FILEBASE$", "/static")
+                html = html.replace(link, new_src)
         return html
 
     def _create_olx_nodes(self, content_type, details):

--- a/tests/fixtures_data/imscc_file/vertical.html
+++ b/tests/fixtures_data/imscc_file/vertical.html
@@ -8,5 +8,6 @@
 </head>
 <body>
 <img src="%24IMS-CC-FILEBASE%24/QuizImages/fractal.jpg" alt="fractal.jpg" width="500" height="375" />
+<p>Fractal Image <a href="%24IMS-CC-FILEBASE%24/QuizImages/fractal.jpg?canvas_download=1" target="_blank">Fractal Image</a></p>
 </body>
 </html>

--- a/tests/fixtures_data/studio_course_xml/course.xml
+++ b/tests/fixtures_data/studio_course_xml/course.xml
@@ -15,6 +15,7 @@
 </head>
 <body>
 <img src="/static/QuizImages/fractal.jpg" alt="fractal.jpg" width="500" height="375" />
+<p>Fractal Image <a href="/static/QuizImages/fractal.jpg?canvas_download=1" target="_blank">Fractal Image</a></p>
 </body>
 </html>
 ]]>

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -146,7 +146,7 @@ def test_cartridge_get_resource_content(cartridge):
             "height": "500",
             "width": "500",
             "custom_parameters": {}
-         }
+        }
     )
 
     assert cartridge.get_resource_content("resource_3_vertical") == (
@@ -159,7 +159,10 @@ def test_cartridge_get_resource_content(cartridge):
                     '<meta name="workflow_state" content="active"/>\n'
                     '</head>\n<body>\n'
                     '<img src="%24IMS-CC-FILEBASE%24/QuizImages/fractal.jpg" alt="fractal.jpg"'
-                    ' width="500" height="375" />'
-                    '\n</body>\n</html>\n'
+                    ' width="500" height="375" />\n'
+                    '<p>Fractal Image <a '
+                    'href="%24IMS-CC-FILEBASE%24/QuizImages/fractal.jpg?canvas_download=1" '
+                    'target="_blank">Fractal Image</a></p>\n'
+                    '</body>\n</html>\n'
         }
     )


### PR DESCRIPTION
This PR helps to render the anchor tag which has href attribute instead of src.

**JIRA tickets**: [TNL-7963](https://openedx.atlassian.net/browse/TNL-7693)

**Screenshots**: None

**Sandbox URL**: None

**Testing instructions**:

1. cd cc2olx
1. pip install -e .
1. cd tests/fixtures_data/imscc_file
1. zip -r /path/to/<filename>.imscc *
1. cc2olx -i /path/to/<filename>.imscc 

In the CWD there will be an output folder created, there will be a "tar.gz", use that tar.gz file to import the course.
In the vertical section, there will be a link, click the link and the image should open in a new tab.

**Author notes and concerns**:
None


**Reviewers**
- [ ] @kaizoku