### PR TITLE
Fix deprecation warnings, add log statements

### DIFF
--- a/src/cc2olx/filesystem.py
+++ b/src/cc2olx/filesystem.py
@@ -67,6 +67,6 @@ def add_in_tar_gz(archive_name, inputs):
             try:
                 archive.add(file, alternative_name)
             except FileNotFoundError:
-                logger.error("%s was not found. Skipping", str(file), exc_info=True)
+                logger.error("%s was not found. Skipping", str(file))
 
     return archive_name

--- a/src/cc2olx/main.py
+++ b/src/cc2olx/main.py
@@ -2,7 +2,6 @@ import logging
 import shutil
 import sys
 import tempfile
-import traceback
 
 from pathlib import Path
 
@@ -46,6 +45,7 @@ def main():
     # setup logger
     logging_config = settings["logging_config"]
     logging.basicConfig(level=logging_config["level"], format=logging_config["format"])
+    logger = logging.getLogger()
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         temp_workspace = Path(tmpdirname) / workspace.stem
@@ -54,7 +54,7 @@ def main():
             try:
                 convert_one_file(input_file, temp_workspace)
             except Exception:
-                traceback.print_exc()
+                logger.exception("Error while converting %s file", input_file)
 
         if settings["output_format"] == RESULT_TYPE_FOLDER:
             shutil.rmtree(str(workspace), ignore_errors=True)
@@ -62,6 +62,8 @@ def main():
 
         if settings["output_format"] == RESULT_TYPE_ZIP:
             shutil.make_archive(str(workspace), "zip", str(temp_workspace))
+
+    logger.info("Conversion completed")
 
     return 0
 

--- a/src/cc2olx/qti.py
+++ b/src/cc2olx/qti.py
@@ -326,10 +326,7 @@ class QtiParser:
                 data.update(parse_problem(problem))
                 parsed_problems.append(data)
             except NotImplementedError:
-                logger.info(
-                    "Problem with ID %s can't be converted.",
-                    problem.attrib.get("ident"),
-                )
+                logger.info("Problem with ID %s can't be converted.", problem.attrib.get("ident"))
                 logger.info("    Profile %s is not supported.", cc_profile)
                 logger.info("    At file %s.", self.resource_filename)
 
@@ -559,7 +556,7 @@ class QtiParser:
         itemfeedback = problem.find("qti:itemfeedback", self.NS)
 
         data["problem_description"] = presentation.find("qti:material/qti:mattext", self.NS).text
-        if itemfeedback:
+        if itemfeedback is not None:
             sample_solution_selector = "qti:solution/qti:solutionmaterial/qti:material/qti:mattext"
             data["sample_solution"] = itemfeedback.find(sample_solution_selector, self.NS).text
         return data


### PR DESCRIPTION
Fixes warnings like:
```
FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
```

Also removes redundant logging of stacktrace and adds a few log statements.