### PR TITLE
Black formatting

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,4 +4,4 @@
 #
 #    make upgrade
 #
-lxml==4.6.1               # via -r requirements/base.in
+lxml==4.6.2               # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,32 +4,38 @@
 #
 #    make upgrade
 #
-appdirs==1.4.4            # via -r requirements/travis.txt, virtualenv
+appdirs==1.4.4            # via -r requirements/quality.txt, -r requirements/travis.txt, black, virtualenv
 attrs==20.3.0             # via -r requirements/quality.txt, pytest
+black==20.8b1             # via -r requirements/quality.txt
 bleach==3.2.1             # via readme-renderer
 bump2version==1.0.1       # via -r requirements/dev.in
 certifi==2020.11.8        # via -r requirements/travis.txt, requests
+cffi==1.14.4              # via cryptography
 chardet==3.0.4            # via -r requirements/travis.txt, requests
-click==7.1.2              # via -r requirements/pip-tools.txt, pip-tools
+click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, black, pip-tools
 codecov==2.1.10           # via -r requirements/travis.txt
+colorama==0.4.4           # via twine
 coverage==5.3             # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
+cryptography==3.2.1       # via secretstorage
 distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
 docutils==0.16            # via readme-renderer
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 flake8==3.8.4             # via -r requirements/quality.txt
 idna==2.10                # via -r requirements/travis.txt, requests
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/travis.txt, flake8, pluggy, pytest, tox, virtualenv
-importlib-resources==3.2.1  # via -r requirements/travis.txt, virtualenv
 iniconfig==1.1.1          # via -r requirements/quality.txt, pytest
-lxml==4.6.1               # via -r requirements/quality.txt
+jeepney==0.6.0            # via keyring, secretstorage
+keyring==21.5.0           # via twine
+lxml==4.6.2               # via -r requirements/quality.txt
 mccabe==0.6.1             # via -r requirements/quality.txt, flake8
-packaging==20.4           # via -r requirements/quality.txt, -r requirements/travis.txt, bleach, pytest, tox
-pathlib2==2.3.5           # via -r requirements/quality.txt, pytest
-pip-tools==5.3.1          # via -r requirements/pip-tools.txt
+mypy-extensions==0.4.3    # via -r requirements/quality.txt, black
+packaging==20.7           # via -r requirements/quality.txt, -r requirements/travis.txt, bleach, pytest, tox
+pathspec==0.8.1           # via -r requirements/quality.txt, black
+pip-tools==5.4.0          # via -r requirements/pip-tools.txt
 pkginfo==1.6.1            # via twine
 pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 py==1.9.0                 # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.txt, flake8
+pycparser==2.20           # via cffi
 pyflakes==2.2.0           # via -r requirements/quality.txt, flake8
 pygments==2.7.2           # via readme-renderer
 pyparsing==2.4.7          # via -r requirements/quality.txt, -r requirements/travis.txt, packaging
@@ -37,19 +43,23 @@ pytest-cov==2.10.1        # via -r requirements/quality.txt
 pytest-mock==3.3.1        # via -r requirements/quality.txt
 pytest==6.1.2             # via -r requirements/quality.txt, pytest-cov, pytest-mock
 readme-renderer==28.0     # via twine
+regex==2020.11.13         # via -r requirements/quality.txt, black
 requests-toolbelt==0.9.1  # via twine
-requests==2.24.0          # via -r requirements/travis.txt, codecov, requests-toolbelt, twine
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, bleach, packaging, pathlib2, pip-tools, readme-renderer, tox, virtualenv
-toml==0.10.2              # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
+requests==2.25.0          # via -r requirements/travis.txt, codecov, requests-toolbelt, twine
+rfc3986==1.4.0            # via twine
+secretstorage==3.3.0      # via keyring
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/travis.txt, bleach, cryptography, pip-tools, readme-renderer, tox, virtualenv
+toml==0.10.2              # via -r requirements/quality.txt, -r requirements/travis.txt, black, pytest, tox
 tox==3.20.1               # via -r requirements/travis.txt
-tqdm==4.51.0              # via twine
-twine==1.15.0             # via -r requirements/dev.in
-urllib3==1.25.11          # via -r requirements/travis.txt, requests
-virtualenv==20.1.0        # via -r requirements/travis.txt, tox
+tqdm==4.54.0              # via twine
+twine==3.2.0              # via -r requirements/dev.in
+typed-ast==1.4.1          # via -r requirements/quality.txt, black
+typing-extensions==3.7.4.3  # via -r requirements/quality.txt, black
+urllib3==1.26.2           # via -r requirements/travis.txt, requests
+virtualenv==20.2.1        # via -r requirements/travis.txt, tox
 webencodings==0.5.1       # via bleach
-wheel==0.35.1             # via -r requirements/dev.in
-xmlformatter==0.2.0       # via -r requirements/quality.txt
-zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
+wheel==0.36.0             # via -r requirements/dev.in
+xmlformatter==0.2.2       # via -r requirements/quality.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.3.1          # via -r requirements/pip-tools.in
+pip-tools==5.4.0          # via -r requirements/pip-tools.in
 six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -3,4 +3,5 @@
 
 -r test.txt               # Core and testing dependencies for this package
 
+black
 flake8

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,15 +4,18 @@
 #
 #    make upgrade
 #
+appdirs==1.4.4            # via black
 attrs==20.3.0             # via -r requirements/test.txt, pytest
+black==20.8b1             # via -r requirements/quality.in
+click==7.1.2              # via black
 coverage==5.3             # via -r requirements/test.txt, pytest-cov
 flake8==3.8.4             # via -r requirements/quality.in
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, flake8, pluggy, pytest
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
-lxml==4.6.1               # via -r requirements/test.txt
+lxml==4.6.2               # via -r requirements/test.txt
 mccabe==0.6.1             # via flake8
-packaging==20.4           # via -r requirements/test.txt, pytest
-pathlib2==2.3.5           # via -r requirements/test.txt, pytest
+mypy-extensions==0.4.3    # via black
+packaging==20.7           # via -r requirements/test.txt, pytest
+pathspec==0.8.1           # via black
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.9.0                 # via -r requirements/test.txt, pytest
 pycodestyle==2.6.0        # via flake8
@@ -21,7 +24,8 @@ pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/test.txt
 pytest-mock==3.3.1        # via -r requirements/test.txt
 pytest==6.1.2             # via -r requirements/test.txt, pytest-cov, pytest-mock
-six==1.15.0               # via -r requirements/test.txt, packaging, pathlib2
-toml==0.10.2              # via -r requirements/test.txt, pytest
-xmlformatter==0.2.0       # via -r requirements/test.txt
-zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata
+regex==2020.11.13         # via black
+toml==0.10.2              # via -r requirements/test.txt, black, pytest
+typed-ast==1.4.1          # via black
+typing-extensions==3.7.4.3  # via black
+xmlformatter==0.2.2       # via -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,18 +6,14 @@
 #
 attrs==20.3.0             # via pytest
 coverage==5.3             # via -r requirements/test.in, pytest-cov
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, pytest
 iniconfig==1.1.1          # via pytest
-lxml==4.6.1               # via -r requirements/base.txt
-packaging==20.4           # via pytest
-pathlib2==2.3.5           # via pytest
+lxml==4.6.2               # via -r requirements/base.txt
+packaging==20.7           # via pytest
 pluggy==0.13.1            # via pytest
 py==1.9.0                 # via pytest
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.1        # via -r requirements/test.in
 pytest-mock==3.3.1        # via -r requirements/test.in
 pytest==6.1.2             # via -r requirements/test.in, pytest-cov, pytest-mock
-six==1.15.0               # via packaging, pathlib2
 toml==0.10.2              # via pytest
-xmlformatter==0.2.0       # via -r requirements/test.in
-zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata
+xmlformatter==0.2.2       # via -r requirements/test.in

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -12,16 +12,13 @@ coverage==5.3             # via -r requirements/travis.in, codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
-importlib-resources==3.2.1  # via virtualenv
-packaging==20.4           # via tox
+packaging==20.7           # via tox
 pluggy==0.13.1            # via tox
 py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
-requests==2.24.0          # via codecov
-six==1.15.0               # via packaging, tox, virtualenv
+requests==2.25.0          # via codecov
+six==1.15.0               # via tox, virtualenv
 toml==0.10.2              # via tox
 tox==3.20.1               # via -r requirements/travis.in
-urllib3==1.25.11          # via requests
-virtualenv==20.1.0        # via tox
-zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources
+urllib3==1.26.2           # via requests
+virtualenv==20.2.1        # via tox

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,9 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Topic :: Utilities",
     ],
-    description=(
-        "Command line tool, that converts Common Cartridge "
-        "courses to Open edX Studio imports."
-    ),
+    description=("Command line tool, that converts Common Cartridge " "courses to Open edX Studio imports."),
     entry_points={"console_scripts": ["cc2olx=cc2olx.main:main"]},
-    install_requires=['lxml'],
+    install_requires=["lxml"],
     license="GNU Affero General Public License",
     long_description=readme,
     include_package_data=True,

--- a/src/cc2olx/cli.py
+++ b/src/cc2olx/cli.py
@@ -9,8 +9,7 @@ RESULT_TYPE_ZIP = "zip"
 def parse_args(args=None):
     parser = argparse.ArgumentParser(
         description=(
-            "This script converts imscc files into folders with "
-            "all the content; in the defined folder structure."
+            "This script converts imscc files into folders with " "all the content; in the defined folder structure."
         )
     )
     parser.add_argument(
@@ -19,10 +18,7 @@ def parse_args(args=None):
         nargs="*",
         type=lambda p: Path(p).absolute(),
         required=True,
-        help=(
-            "Please provide the paths to the imscc files or directories "
-            "that contain them."
-        ),
+        help=("Please provide the paths to the imscc files or directories " "that contain them."),
     )
     parser.add_argument(
         "-l",
@@ -43,9 +39,7 @@ def parse_args(args=None):
         help=(
             "Please provide the format for output. "
             "It can take one of the following "
-            "values, {folder}, {zip} as argument.".format(
-                folder=RESULT_TYPE_FOLDER, zip=RESULT_TYPE_ZIP
-            )
+            "values, {folder}, {zip} as argument.".format(folder=RESULT_TYPE_FOLDER, zip=RESULT_TYPE_ZIP)
         ),
     )
     return parser.parse_args(args)

--- a/src/cc2olx/filesystem.py
+++ b/src/cc2olx/filesystem.py
@@ -25,18 +25,16 @@ def get_xml_tree(path_src):
     Returns:
         ElementTree: This gives back an xml parse tree that can handle different operation
     """
-    logger.info('Loading file %s', path_src)
+    logger.info("Loading file %s", path_src)
     try:
         # We are using this parser with recover and encoding options so that we are
         # able to parse malformed xml without much issue. The xml that we are
         # anticipating can even be having certain non-acceptable characters like &nbsp.
-        parser = etree.XMLParser(encoding='utf-8', recover=True, ns_clean=True)
+        parser = etree.XMLParser(encoding="utf-8", recover=True, ns_clean=True)
         tree = ElementTree.parse(str(path_src), parser=parser)
         return tree
     except ElementTree.ParseError:
-        logger.error(
-            "Error while reading xml from %s.", path_src, exc_info=True
-        )
+        logger.error("Error while reading xml from %s.", path_src, exc_info=True)
 
 
 def unzip_directory(path_src, path_dst_base=None):
@@ -63,14 +61,12 @@ def add_in_tar_gz(archive_name, inputs):
 
     Returns: path to the newly created archive.
     """
-    with tarfile.open(archive_name, 'w:gz') as archive:
+    with tarfile.open(archive_name, "w:gz") as archive:
         for file, alternative_name in inputs:
             # Disregard any file that isn't found
             try:
                 archive.add(file, alternative_name)
             except FileNotFoundError:
-                logger.error(
-                    "%s was not found. Skipping", str(file), exc_info=True
-                )
+                logger.error("%s was not found. Skipping", str(file), exc_info=True)
 
     return archive_name

--- a/src/cc2olx/main.py
+++ b/src/cc2olx/main.py
@@ -21,19 +21,20 @@ def convert_one_file(input_file, workspace):
     cartridge.normalize()
 
     xml = olx.OlxExport(cartridge).xml()
-    olx_filename = cartridge.directory.parent / (
-        cartridge.directory.name + "-course.xml"
-    )
+    olx_filename = cartridge.directory.parent / (cartridge.directory.name + "-course.xml")
 
     with open(str(olx_filename), "w") as olxfile:
         olxfile.write(xml)
 
-    tgz_filename = (workspace / cartridge.directory.name).with_suffix('.tar.gz')
+    tgz_filename = (workspace / cartridge.directory.name).with_suffix(".tar.gz")
 
-    filesystem.add_in_tar_gz(str(tgz_filename), [
-        (str(olx_filename), 'course.xml'),
-        (str(cartridge.directory / 'web_resources'), '/static/')
-    ])
+    filesystem.add_in_tar_gz(
+        str(tgz_filename),
+        [
+            (str(olx_filename), "course.xml"),
+            (str(cartridge.directory / "web_resources"), "/static/"),
+        ],
+    )
 
 
 def main():

--- a/src/cc2olx/models.py
+++ b/src/cc2olx/models.py
@@ -10,31 +10,31 @@ from cc2olx.qti import QtiParser
 
 logger = logging.getLogger()
 
-MANIFEST = 'imsmanifest.xml'
+MANIFEST = "imsmanifest.xml"
 DIFFUSE_SHALLOW_SECTIONS = False
 DIFFUSE_SHALLOW_SUBSECTIONS = True
 
 OLX_DIRECTORIES = [
-    'about',
-    'assets',
-    'chapter',
-    'course',
-    'html',
-    'info',
-    'policies',
-    'problem',
-    'sequential',
-    'static',
-    'vertical',
+    "about",
+    "assets",
+    "chapter",
+    "course",
+    "html",
+    "info",
+    "policies",
+    "problem",
+    "sequential",
+    "static",
+    "vertical",
 ]
 
 
 def is_leaf(container):
-    return 'identifierref' in container
+    return "identifierref" in container
 
 
 def has_only_leaves(container):
-    return all(is_leaf(child) for child in container.get('children', []))
+    return all(is_leaf(child) for child in container.get("children", []))
 
 
 class ResourceFile:
@@ -65,7 +65,7 @@ class Cartridge:
         self.resources_by_id = {}
         self.organizations = None
         self.normalized = None
-        self.version = '1.1'
+        self.version = "1.1"
         self.file_path = cartridge_file
         self.directory = None
         self.ns = {}
@@ -101,10 +101,10 @@ class Cartridge:
             organization = organizations[0]
         if not organization:
             return
-        identifier = organization.get('identifier', 'org_1')
+        identifier = organization.get("identifier", "org_1")
         # An organization may have 0 or 1 item.
         # We'll treat it as the courseware root.
-        course_root = organization.get('children', [])
+        course_root = organization.get("children", [])
         # Question: Does it have it have identifier="LearningModules"?
         count_root = len(course_root)
         if count_root == 0:
@@ -118,11 +118,11 @@ class Cartridge:
             course_root = course_root[0]
         if not course_root:
             return
-        sections = course_root.get('children', [])
+        sections = course_root.get("children", [])
         normal_course = {
-            'children': [],
-            'identifier': identifier,
-            'structure': 'rooted-hierarchy',
+            "children": [],
+            "identifier": identifier,
+            "structure": "rooted-hierarchy",
         }
         for section in sections:
             if is_leaf(section):
@@ -137,29 +137,29 @@ class Cartridge:
                 if DIFFUSE_SHALLOW_SECTIONS:
                     subsections = [
                         {
-                            'identifier': 'x'*34,
-                            'title': 'none',
-                            'children': [
+                            "identifier": "x" * 34,
+                            "title": "none",
+                            "children": [
                                 subsection,
                             ],
                         }
-                        for subsection in section.get('children', [])
+                        for subsection in section.get("children", [])
                     ]
                 else:
                     subsections = [
                         {
-                            'identifier': 'x'*34,
-                            'title': 'none',
-                            'children': section.get('children', []),
+                            "identifier": "x" * 34,
+                            "title": "none",
+                            "children": section.get("children", []),
                         },
                     ]
             else:
-                subsections = section.get('children', [])
+                subsections = section.get("children", [])
             normal_section = {
-                'children': [],
-                'identifier': section.get('identifier'),
-                'identifierref': section.get('identifierref'),
-                'title': section.get('title'),
+                "children": [],
+                "identifier": section.get("identifier"),
+                "identifierref": section.get("identifierref"),
+                "title": section.get("title"),
             }
             if len(subsections) == 1:
                 subsect = subsections[0]
@@ -178,29 +178,29 @@ class Cartridge:
                     if DIFFUSE_SHALLOW_SUBSECTIONS:
                         units = [
                             {
-                                'identifier': 'x'*34,
-                                'title': unit.get('title', 'none'),
-                                'children': [
+                                "identifier": "x" * 34,
+                                "title": unit.get("title", "none"),
+                                "children": [
                                     unit,
                                 ],
                             }
-                            for unit in subsection.get('children', [])
+                            for unit in subsection.get("children", [])
                         ]
                     else:
                         units = [
                             {
-                                'identifier': 'x'*34,
-                                'title': 'none',
-                                'children': subsection.get('children', []),
+                                "identifier": "x" * 34,
+                                "title": "none",
+                                "children": subsection.get("children", []),
                             },
                         ]
                 else:
-                    units = subsection.get('children', [])
+                    units = subsection.get("children", [])
                 normal_subsection = {
-                    'children': [],
-                    'identifier': subsection.get('identifier'),
-                    'identifierref': subsection.get('identifierref'),
-                    'title': subsection.get('title'),
+                    "children": [],
+                    "identifier": subsection.get("identifier"),
+                    "identifierref": subsection.get("identifierref"),
+                    "title": subsection.get("title"),
                 }
                 for unit in units:
                     if is_leaf(unit):
@@ -210,19 +210,19 @@ class Cartridge:
                             unit,
                         ]
                     else:
-                        components = unit.get('children', [])
+                        components = unit.get("children", [])
                         components = self.flatten(components)
                     normal_unit = {
-                        'children': [],
-                        'identifier': unit.get('identifier'),
-                        'identifierref': unit.get('identifierref'),
-                        'title': unit.get('title'),
+                        "children": [],
+                        "identifier": unit.get("identifier"),
+                        "identifierref": unit.get("identifierref"),
+                        "title": unit.get("title"),
                     }
                     for component in components:
-                        normal_unit['children'].append(component)
-                    normal_subsection['children'].append(normal_unit)
-                normal_section['children'].append(normal_subsection)
-            normal_course['children'].append(normal_section)
+                        normal_unit["children"].append(component)
+                    normal_subsection["children"].append(normal_unit)
+                normal_section["children"].append(normal_subsection)
+            normal_course["children"].append(normal_section)
         self.normalized = normal_course
         return normal_course
 
@@ -235,7 +235,7 @@ class Cartridge:
             # Structure is too deep.
             # Flatten into current unit?
             # Found non-leaf at component level
-            children = container.get('children', [])
+            children = container.get("children", [])
         output = []
         for child in children:
             if is_leaf(child):
@@ -272,12 +272,14 @@ class Cartridge:
                     logger.error("Failure reading %s from id %s", res_filename, identifier)  # noqa: E722
                     raise
                 return "html", {"html": html}
-            elif 'web_resources' in str(res_filename) and imghdr.what(str(res_filename)):
-                static_filename = str(res_filename).split('web_resources/')[1]
-                html = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>' \
+            elif "web_resources" in str(res_filename) and imghdr.what(str(res_filename)):
+                static_filename = str(res_filename).split("web_resources/")[1]
+                html = (
+                    '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>'
                     '</head><body><p><img src="{}" alt="{}"></p></body></html>'.format(
-                        '/static/'+static_filename, static_filename
+                        "/static/" + static_filename, static_filename
                     )
+                )
                 return "html", {"html": html}
             else:
                 logger.info("Skipping webcontent: %s", res_filename)
@@ -293,7 +295,7 @@ class Cartridge:
             data = self._parse_lti(res)
             return "lti", data
         elif res_type == "imsqti_xmlv1p2/imscc_xmlv1p1/assessment":
-            res_filename = self._res_filename(res['children'][0].href)
+            res_filename = self._res_filename(res["children"][0].href)
             qti_parser = QtiParser(res_filename)
             return "qti", qti_parser.parse_qti()
         elif res_type == "imsdt_xmlv1p1":
@@ -312,17 +314,17 @@ class Cartridge:
         root = tree.getroot()
         self._update_namespaces(root)
         data = self._parse_manifest(root)
-        self.metadata = data['metadata']
-        self.organizations = data['organizations']
-        self.resources = data['resources']
-        self.resources_by_id = {r['identifier']: r for r in self.resources}
-        self.version = self.metadata.get('schema', {}).get('version', self.version)
+        self.metadata = data["metadata"]
+        self.organizations = data["organizations"]
+        self.resources = data["resources"]
+        self.resources_by_id = {r["identifier"]: r for r in self.resources}
+        self.version = self.metadata.get("schema", {}).get("version", self.version)
         return data
 
     def write_xml(self, text, output_base, output_file):
-        text += '\n'
+        text += "\n"
         output_path = os.path.join(output_base, output_file)
-        with open(output_path, 'w') as output:
+        with open(output_path, "w") as output:
             output.write(text)
 
     def get_course_xml(self):
@@ -334,39 +336,45 @@ class Cartridge:
         return text
 
     def get_run_xml(self):
-        text = dedent("""\
+        text = (
+            dedent(
+                """\
             <course
                 display_name="{title}"
                 language="{language}"
             >
             </course>\
-        """).format(
-            title=self.get_title(),
-            language=self.get_language(),
-        ).strip()
+        """
+            )
+            .format(
+                title=self.get_title(),
+                language=self.get_language(),
+            )
+            .strip()
+        )
         return text
 
     def get_title(self):
         # TODO: Choose a better default course title
-        title = self.metadata.get('lom', {}).get('general', {}).get('title') or 'Default Course Title'
+        title = self.metadata.get("lom", {}).get("general", {}).get("title") or "Default Course Title"
         return title
 
     def get_language(self):
         # TODO: ensure the type of language code in the metadata
-        title = self.metadata.get('lom', {}).get('general', {}).get('language') or 'en'
+        title = self.metadata.get("lom", {}).get("general", {}).get("language") or "en"
         return title
 
     def get_course_org(self):
         # TODO: find a better value for this
-        return 'org'
+        return "org"
 
     def get_course_number(self):
         # TODO: find a better value for this
-        return 'number'
+        return "number"
 
     def get_course_run(self):
         # TODO: find a better value for this; lifecycle.contribute_date?
-        return 'run'
+        return "run"
 
     def _extract(self):
         path_extracted = filesystem.unzip_directory(self.file_path, self.workspace)
@@ -375,65 +383,65 @@ class Cartridge:
         return manifest
 
     def _update_namespaces(self, root):
-        ns = re.match(r'\{(.*)\}', root.tag).group(1)
-        version = re.match(r'.*/(imsccv\dp\d)/', ns).group(1)
+        ns = re.match(r"\{(.*)\}", root.tag).group(1)
+        version = re.match(r".*/(imsccv\dp\d)/", ns).group(1)
 
-        self.ns['ims'] = ns
-        self.ns['lomimscc'] = "http://ltsc.ieee.org/xsd/{version}/LOM/manifest".format(
+        self.ns["ims"] = ns
+        self.ns["lomimscc"] = "http://ltsc.ieee.org/xsd/{version}/LOM/manifest".format(
             version=version,
         )
 
     def _parse_manifest(self, node):
         data = dict()
-        data['metadata'] = self._parse_metadata(node)
-        data['organizations'] = self._parse_organizations(node)
-        data['resources'] = self._parse_resources(node)
+        data["metadata"] = self._parse_metadata(node)
+        data["organizations"] = self._parse_organizations(node)
+        data["resources"] = self._parse_resources(node)
         return data
 
     def _parse_metadata(self, node):
         data = dict()
-        metadata = node.find('./ims:metadata', self.ns)
+        metadata = node.find("./ims:metadata", self.ns)
         if metadata:
-            data['schema'] = self._parse_schema(metadata)
-            data['lom'] = self._parse_lom(metadata)
+            data["schema"] = self._parse_schema(metadata)
+            data["lom"] = self._parse_lom(metadata)
         return data
 
     def _parse_schema(self, node):
         schema_name = self._parse_schema_name(node)
         schema_version = self._parse_schema_version(node)
         data = {
-            'name': schema_name,
-            'version': schema_version,
+            "name": schema_name,
+            "version": schema_version,
         }
         return data
 
     def _parse_schema_name(self, node):
-        schema_name = node.find('./ims:schema', self.ns)
+        schema_name = node.find("./ims:schema", self.ns)
         schema_name = schema_name.text
         return schema_name
 
     def _parse_schema_version(self, node):
-        schema_version = node.find('./ims:schemaversion', self.ns)
+        schema_version = node.find("./ims:schemaversion", self.ns)
         schema_version = schema_version.text
         return schema_version
 
     def _parse_lom(self, node):
         data = dict()
-        lom = node.find('lomimscc:lom', self.ns)
+        lom = node.find("lomimscc:lom", self.ns)
         if lom:
-            data['general'] = self._parse_general(lom)
-            data['lifecycle'] = self._parse_lifecycle(lom)
-            data['rights'] = self._parse_rights(lom)
+            data["general"] = self._parse_general(lom)
+            data["lifecycle"] = self._parse_lifecycle(lom)
+            data["rights"] = self._parse_rights(lom)
         return data
 
     def _parse_general(self, node):
         data = {}
-        general = node.find('lomimscc:general', self.ns)
+        general = node.find("lomimscc:general", self.ns)
         if general:
-            data['title'] = self._parse_text(general, 'lomimscc:title/lomimscc:string')
-            data['language'] = self._parse_text(general, 'lomimscc:language/lomimscc:string')
-            data['description'] = self._parse_text(general, 'lomimscc:description/lomimscc:string')
-            data['keywords'] = self._parse_keywords(general)
+            data["title"] = self._parse_text(general, "lomimscc:title/lomimscc:string")
+            data["language"] = self._parse_text(general, "lomimscc:language/lomimscc:string")
+            data["description"] = self._parse_text(general, "lomimscc:description/lomimscc:string")
+            data["keywords"] = self._parse_keywords(general)
         return data
 
     def _parse_text(self, node, lookup):
@@ -450,15 +458,15 @@ class Cartridge:
 
     def _parse_rights(self, node):
         data = dict()
-        element = node.find('lomimscc:rights', self.ns)
+        element = node.find("lomimscc:rights", self.ns)
         if element:
-            data['is_restricted'] = self._parse_text(
+            data["is_restricted"] = self._parse_text(
                 element,
-                'lomimscc:copyrightAndOtherRestrictions/lomimscc:value',
+                "lomimscc:copyrightAndOtherRestrictions/lomimscc:value",
             )
-            data['description'] = self._parse_text(
+            data["description"] = self._parse_text(
                 element,
-                'lomimscc:description/lomimscc:string',
+                "lomimscc:description/lomimscc:string",
             )
             # TODO: cost
         return data
@@ -468,105 +476,99 @@ class Cartridge:
         # TODO: entity
         data = dict()
         contribute_date = node.find(
-            'lomimscc:lifeCycle/lomimscc:contribute/lomimscc:date/lomimscc:dateTime',
-            self.ns
+            "lomimscc:lifeCycle/lomimscc:contribute/lomimscc:date/lomimscc:dateTime",
+            self.ns,
         )
         text = None
         if contribute_date is not None:
             text = contribute_date.text
-        data['contribute_date'] = text
+        data["contribute_date"] = text
         return data
 
     def _parse_organizations(self, node):
         data = []
-        element = node.find('ims:organizations', self.ns) or []
-        data = [
-            self._parse_organization(org_node)
-            for org_node in element
-        ]
+        element = node.find("ims:organizations", self.ns) or []
+        data = [self._parse_organization(org_node) for org_node in element]
         return data
 
     def _parse_organization(self, node):
         data = {}
-        data['identifier'] = node.get('identifier')
-        data['structure'] = node.get('structure')
+        data["identifier"] = node.get("identifier")
+        data["structure"] = node.get("structure")
         children = []
         for item_node in node:
             child = self._parse_item(item_node)
             if len(child):
                 children.append(child)
         if len(children):
-            data['children'] = children
+            data["children"] = children
         return data
 
     def _parse_item(self, node):
         data = {}
-        identifier = node.get('identifier')
+        identifier = node.get("identifier")
         if identifier:
-            data['identifier'] = identifier
-        identifierref = node.get('identifierref')
+            data["identifier"] = identifier
+        identifierref = node.get("identifierref")
         if identifierref:
-            data['identifierref'] = identifierref
-        title = self._parse_text(node, 'ims:title')
+            data["identifierref"] = identifierref
+        title = self._parse_text(node, "ims:title")
         if title:
-            data['title'] = title
+            data["title"] = title
         children = []
         for child in node:
             child_item = self._parse_item(child)
             if len(child_item):
                 children.append(child_item)
         if children and len(children):
-            data['children'] = children
+            data["children"] = children
         return data
 
     def _parse_resources(self, node):
-        element = node.find('ims:resources', self.ns) or []
-        data = [
-            self._parse_resource(sub_element)
-            for sub_element in element
-        ]
+        element = node.find("ims:resources", self.ns) or []
+        data = [self._parse_resource(sub_element) for sub_element in element]
         return data
 
     def _parse_resource(self, node):
         data = {}
-        identifier = node.get('identifier')
+        identifier = node.get("identifier")
         if identifier:
-            data['identifier'] = identifier
-        _type = node.get('type')
+            data["identifier"] = identifier
+        _type = node.get("type")
         if _type:
-            data['type'] = _type
-        href = node.get('href')
+            data["type"] = _type
+        href = node.get("href")
         if href:
-            data['href'] = href
-        intended_use = node.get('intended_use')
+            data["href"] = href
+        intended_use = node.get("intended_use")
         if intended_use:
-            data['intended_use'] = intended_use
+            data["intended_use"] = intended_use
         children = []
         for child in node:
-            prefix, has_namespace, postfix = child.tag.partition('}')
+            prefix, has_namespace, postfix = child.tag.partition("}")
             tag = postfix
-            if tag == 'file':
+            if tag == "file":
                 child_data = self._parse_file(child)
-            elif tag == 'dependency':
+            elif tag == "dependency":
                 child_data = self._parse_dependency(child)
-            elif tag == 'metadata':
+            elif tag == "metadata":
                 child_data = self._parse_resource_metadata(child)
             else:
-                logger.info('Unsupported Resource Type %s', tag)
+                logger.info("Unsupported Resource Type %s", tag)
                 continue
             if child_data:
                 children.append(child_data)
         if children and len(children):
-            data['children'] = children
+            data["children"] = children
         return data
 
     def _parse_file(self, node):
-        href = node.get('href')
+        href = node.get("href")
         resource = ResourceFile(href)
         return resource
 
     def _parse_dependency(self, node):
-        identifierref = node.get('identifierref')
+        identifierref = node.get("identifierref")
         resource = ResourceDependency(identifierref)
         return resource
 
@@ -582,55 +584,50 @@ class Cartridge:
         Parses resource of ``imsbasiclti_xmlv1p0`` type.
         """
 
-        tree = filesystem.get_xml_tree(self._res_filename(resource['children'][0].href))
+        tree = filesystem.get_xml_tree(self._res_filename(resource["children"][0].href))
         root = tree.getroot()
         ns = {
-            'blti': 'http://www.imsglobal.org/xsd/imsbasiclti_v1p0',
-            'lticp': 'http://www.imsglobal.org/xsd/imslticp_v1p0',
-            'lticm': 'http://www.imsglobal.org/xsd/imslticm_v1p0',
+            "blti": "http://www.imsglobal.org/xsd/imsbasiclti_v1p0",
+            "lticp": "http://www.imsglobal.org/xsd/imslticp_v1p0",
+            "lticm": "http://www.imsglobal.org/xsd/imslticm_v1p0",
         }
-        title = root.find('blti:title', ns).text
-        description = root.find('blti:description', ns).text
-        launch_url = root.find('blti:secure_launch_url', ns)
+        title = root.find("blti:title", ns).text
+        description = root.find("blti:description", ns).text
+        launch_url = root.find("blti:secure_launch_url", ns)
         if launch_url is None:
-            launch_url = root.find('blti:launch_url', ns)
+            launch_url = root.find("blti:launch_url", ns)
         if launch_url is not None:
             launch_url = launch_url.text
         else:
-            launch_url = ''
+            launch_url = ""
         width = root.find("blti:extensions/lticm:property[@name='selection_width']", ns)
         if width is None:
-            width = '500'
+            width = "500"
         else:
             width = width.text
         height = root.find("blti:extensions/lticm:property[@name='selection_height']", ns)
         if height is None:
-            height = '500'
+            height = "500"
         else:
             height = height.text
-        custom = root.find('blti:custom', ns)
+        custom = root.find("blti:custom", ns)
         if custom is None:
             parameters = dict()
         else:
-            parameters = {
-                option.get('name'): option.text
-                for option in custom
-            }
+            parameters = {option.get("name"): option.text for option in custom}
         data = {
-            'title': title,
-            'description': description,
-            'launch_url': launch_url,
-            'height': height,
-            'width': width,
-            'custom_parameters': parameters,
+            "title": title,
+            "description": description,
+            "launch_url": launch_url,
+            "height": height,
+            "width": width,
+            "custom_parameters": parameters,
         }
         return data
 
     def _parse_discussion(self, res):
-        data = {
-            'dependencies': []
-        }
-        for child in res['children']:
+        data = {"dependencies": []}
+        for child in res["children"]:
             if isinstance(child, ResourceFile):
                 tree = filesystem.get_xml_tree(self._res_filename(child.href))
                 root = tree.getroot()
@@ -638,5 +635,5 @@ class Cartridge:
                 data["title"] = root.find("dt:title", ns).text
                 data["text"] = root.find("dt:text", ns).text
             elif isinstance(child, ResourceDependency):
-                data['dependencies'].append(self.get_resource_content(child.identifierref))
+                data["dependencies"].append(self.get_resource_content(child.identifierref))
         return data

--- a/src/cc2olx/olx.py
+++ b/src/cc2olx/olx.py
@@ -43,7 +43,7 @@ class OlxExport:
         self.doc.appendChild(xcourse)
 
         tags = "chapter sequential vertical".split()
-        self._add_olx_nodes(xcourse, self.cartridge.normalized['children'], tags)
+        self._add_olx_nodes(xcourse, self.cartridge.normalized["children"], tags)
 
         return self.doc.toprettyxml()
 
@@ -123,7 +123,7 @@ class OlxExport:
         # Here the attributes that are tageted are href and src
         srcs = re.findall(r'(src|href)\s*=\s*"(.+?)"', html)
         for tag, link in srcs:
-            if 'IMS-CC-FILEBASE' in link:
+            if "IMS-CC-FILEBASE" in link:
                 new_src = urllib.parse.unquote(link).replace("$IMS-CC-FILEBASE$", "/static")
                 html = html.replace(link, new_src)
         return html
@@ -162,37 +162,39 @@ class OlxExport:
             nodes += self._create_discussion_node(details)
 
         else:
-            raise OlxExportException("Content type \"{}\" is not supported.".format(content_type))
+            raise OlxExportException('Content type "{}" is not supported.'.format(content_type))
 
         return nodes
 
     def _create_lti_node(self, details):
-        node = self.doc.createElement('lti_consumer')
+        node = self.doc.createElement("lti_consumer")
         custom_parameters = "[{params}]".format(
-            params=', '.join([
-                '"{key}={value}"'.format(
-                    key=key,
-                    value=value,
-                )
-                for key, value in details['custom_parameters'].items()
-            ]),
+            params=", ".join(
+                [
+                    '"{key}={value}"'.format(
+                        key=key,
+                        value=value,
+                    )
+                    for key, value in details["custom_parameters"].items()
+                ]
+            ),
         )
-        node.setAttribute('custom_parameters', custom_parameters)
-        node.setAttribute('description', details['description'])
-        node.setAttribute('display_name', details['title'])
-        node.setAttribute('inline_height', details['height'])
-        node.setAttribute('inline_width', details['width'])
-        node.setAttribute('launch_url', details['launch_url'])
-        node.setAttribute('modal_height', details['height'])
-        node.setAttribute('modal_width', details['width'])
-        node.setAttribute('xblock-family', 'xblock.v1')
+        node.setAttribute("custom_parameters", custom_parameters)
+        node.setAttribute("description", details["description"])
+        node.setAttribute("display_name", details["title"])
+        node.setAttribute("inline_height", details["height"])
+        node.setAttribute("inline_width", details["width"])
+        node.setAttribute("launch_url", details["launch_url"])
+        node.setAttribute("modal_height", details["height"])
+        node.setAttribute("modal_width", details["width"])
+        node.setAttribute("xblock-family", "xblock.v1")
         return node
 
     def _create_discussion_node(self, details):
-        node = self.doc.createElement('discussion')
-        node.setAttribute('display_name', '')
-        node.setAttribute('discussion_category', details['title'])
-        node.setAttribute('discussion_target', details['title'])
+        node = self.doc.createElement("discussion")
+        node.setAttribute("display_name", "")
+        node.setAttribute("discussion_category", details["title"])
+        node.setAttribute("discussion_target", details["title"])
         html_node = self.doc.createElement("html")
         txt = self.doc.createCDATASection(details["text"])
         html_node.appendChild(txt)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,10 +8,12 @@ def test_parse_args(imscc_file):
     Basic cli test.
     """
 
-    parsed_args = parse_args([
-        "-i",
-        str(imscc_file),
-    ])
+    parsed_args = parse_args(
+        [
+            "-i",
+            str(imscc_file),
+        ]
+    )
 
     assert parsed_args == Namespace(
         inputs=[imscc_file],

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -33,7 +33,8 @@ def test_load_manifest_extracted(imscc_file, settings, temp_workspace_dir):
     assert cartridge.directory == Path(temp_workspace_dir.strpath) / "output" / imscc_file.stem
 
     assert cartridge.metadata["schema"] == {
-        "name": "IMS Common Cartridge", "version": cartridge_version
+        "name": "IMS Common Cartridge",
+        "version": cartridge_version,
     }
 
     assert len(cartridge.resources) == 8
@@ -81,12 +82,12 @@ def test_cartridge_normalize(imscc_file, settings):
                                     {
                                         "identifier": "qti",
                                         "identifierref": "resource_4_qti",
-                                        "title": "QTI"
+                                        "title": "QTI",
                                     }
                                 ],
                                 "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
                                 "identifierref": None,
-                                "title": "QTI"
+                                "title": "QTI",
                             },
                             {
                                 "children": [
@@ -105,7 +106,7 @@ def test_cartridge_normalize(imscc_file, settings):
                                     {
                                         "identifier": "image_file",
                                         "title": "Image File Webcontent",
-                                        "identifierref": "resource_5_image_file"
+                                        "identifierref": "resource_5_image_file",
                                     }
                                 ],
                                 "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
@@ -133,8 +134,8 @@ def test_cartridge_get_resource_content(cartridge):
         "html",
         {
             "html": "Unimported content: type = 'associatedcontent/imscc_xmlv1p1/learning-application-resource', "
-                    "href = 'course_settings/canvas_export.txt'"
-        }
+            "href = 'course_settings/canvas_export.txt'"
+        },
     )
 
     assert cartridge.get_resource_content("resource_2_lti") == (
@@ -145,24 +146,24 @@ def test_cartridge_get_resource_content(cartridge):
             "launch_url": "https://lti.local/launch",
             "height": "500",
             "width": "500",
-            "custom_parameters": {}
-        }
+            "custom_parameters": {},
+        },
     )
 
     assert cartridge.get_resource_content("resource_3_vertical") == (
-        'html',
+        "html",
         {
             "html": '<html>\n<head>\n<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>\n'
-                    '<title>Vertical</title>\n'
-                    '<meta name="identifier" content="resource_3_vertical"/>\n'
-                    '<meta name="editing_roles" content="teachers"/>\n'
-                    '<meta name="workflow_state" content="active"/>\n'
-                    '</head>\n<body>\n'
-                    '<img src="%24IMS-CC-FILEBASE%24/QuizImages/fractal.jpg" alt="fractal.jpg"'
-                    ' width="500" height="375" />\n'
-                    '<p>Fractal Image <a '
-                    'href="%24IMS-CC-FILEBASE%24/QuizImages/fractal.jpg?canvas_download=1" '
-                    'target="_blank">Fractal Image</a></p>\n'
-                    '</body>\n</html>\n'
-        }
+            "<title>Vertical</title>\n"
+            '<meta name="identifier" content="resource_3_vertical"/>\n'
+            '<meta name="editing_roles" content="teachers"/>\n'
+            '<meta name="workflow_state" content="active"/>\n'
+            "</head>\n<body>\n"
+            '<img src="%24IMS-CC-FILEBASE%24/QuizImages/fractal.jpg" alt="fractal.jpg"'
+            ' width="500" height="375" />\n'
+            "<p>Fractal Image <a "
+            'href="%24IMS-CC-FILEBASE%24/QuizImages/fractal.jpg?canvas_download=1" '
+            'target="_blank">Fractal Image</a></p>\n'
+            "</body>\n</html>\n"
+        },
     )

--- a/tests/test_olx.py
+++ b/tests/test_olx.py
@@ -9,17 +9,15 @@ def test_olx_export(cartridge, studio_course_xml):
 
 
 def test_process_link():
-    details = {
-        "href": "https://example.com/path"
-    }
-    details_with_youtube_link = {
-        "href": "https://www.youtube.com/watch?v=gQ-cZRmHfs4&amp;amp;list=PL5B350D511278A56B"
-    }
+    details = {"href": "https://example.com/path"}
+    details_with_youtube_link = {"href": "https://www.youtube.com/watch?v=gQ-cZRmHfs4&amp;amp;list=PL5B350D511278A56B"}
 
     assert olx.process_link(details) == (
-        "html", {"html": "<a href='{}'></a>".format(details["href"])}
+        "html",
+        {"html": "<a href='{}'></a>".format(details["href"])},
     )
 
     assert olx.process_link(details_with_youtube_link) == (
-        "video", {"youtube": "gQ-cZRmHfs4"}
+        "video",
+        {"youtube": "gQ-cZRmHfs4"},
     )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,19 +5,16 @@ from cc2olx.settings import collect_settings
 
 
 def test_collect_settings(imscc_file):
-    parsed_args = parse_args([
-        "-i",
-        str(imscc_file)
-    ])
+    parsed_args = parse_args(["-i", str(imscc_file)])
 
     settings = collect_settings(parsed_args)
 
     assert settings == {
-        "input_files":  {imscc_file},
+        "input_files": {imscc_file},
         "output_format": parsed_args.result,
         "workspace": Path.cwd() / "output",
         "logging_config": {
             "level": parsed_args.loglevel,
             "format": "{%(filename)s:%(lineno)d} - %(message)s",
-        }
+        },
     }

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,15 @@
 [tox]
-envlist = py35, py38, quality
+envlist = py35, py38, quality, formatting
 
 [testenv:quality]
 basepython = python
 deps = flake8
 commands = flake8 src tests
+
+[testenv:formatting]
+basepython = python
+deps = black
+commands = black --check --diff --line-length 120 src tests setup.py
 
 [testenv]
 setenv =


### PR DESCRIPTION
This PR reformats all python code (with exception for OLX constructing code) using `black` tool, and enables formatting checking in Travis.

**Testing instructions**:

1. Add many blank lines somewhere in `setup.py`.
2. Run `tox`. It should fail.

**Reviewers**
- [ ] @alangsto 