### PR TITLE
Update README.rst and reformatted code

### DIFF
--- a/src/cc2olx/iframe_link_parser.py
+++ b/src/cc2olx/iframe_link_parser.py
@@ -23,7 +23,7 @@ class IframeLinkParser:
         Returns:
             [str]: The whole URL string which was embedded inside iframe.
         """
-        return iframe_element.attrib['src']
+        return iframe_element.attrib["src"]
 
     def _get_video_url(self, iframes):
         """
@@ -91,11 +91,11 @@ class IframeLinkParser:
         """
         xml_element = element_builder(doc)
         attributes = {}
-        edx_id = url_row['Edx Id']
-        youtube_id = url_row['Youtube Id']
-        if edx_id.strip() != '':
+        edx_id = url_row["Edx Id"]
+        youtube_id = url_row["Youtube Id"]
+        if edx_id.strip() != "":
             attributes["edx_video_id"] = edx_id
-        elif youtube_id.strip() != '':
+        elif youtube_id.strip() != "":
             attributes["youtube"] = "1.00:" + youtube_id
             attributes["youtube_id_1_0"] = youtube_id
         child = xml_element("video", children=None, attributes=attributes)
@@ -144,7 +144,7 @@ class KalturaIframeLinkParser(IframeLinkParser):
             [str]: The base URL for kaltura. eg.
             https://cdnapisec.kaltura.com/p/2019031/sp/201903100/
         """
-        url = src.split('embedIframeJs')
+        url = src.split("embedIframeJs")
         net_location = url[0].strip()
         return net_location
 
@@ -162,7 +162,7 @@ class KalturaIframeLinkParser(IframeLinkParser):
         parsed_url = urlparse(src)
         query = parsed_url.query
         query_dict = parse_qs(query)
-        entry_id_query = query_dict.get('entry_id')
+        entry_id_query = query_dict.get("entry_id")
         if entry_id_query:
             entry_id = entry_id_query[0]
         return entry_id

--- a/src/cc2olx/link_file_reader.py
+++ b/src/cc2olx/link_file_reader.py
@@ -23,7 +23,7 @@ class LinkFileReader:
             file_path ([str]): Link map file path.
         """
         self.file_path = file_path
-        self.link_header = 'External Video Link'
+        self.link_header = "External Video Link"
 
     def get_link_map(self):
         """
@@ -47,7 +47,7 @@ class LinkFileReader:
         Returns:
             [List[Dict]]: List of dictionary with each header
         """
-        with open(self.file_path, encoding='utf-8') as csvfile:
+        with open(self.file_path, encoding="utf-8") as csvfile:
             reader = csv.DictReader(csvfile)
             rows = [row for row in reader]
         return rows

--- a/src/cc2olx/olx.py
+++ b/src/cc2olx/olx.py
@@ -212,10 +212,7 @@ class OlxExport:
             [OLX Element]: Video OLX element.
         """
         xml_element = element_builder(self.doc)
-        attributes = {
-            "youtube": "1.00:" + details["youtube"],
-            "youtube_id_1_0": details["youtube"]
-        }
+        attributes = {"youtube": "1.00:" + details["youtube"], "youtube_id_1_0": details["youtube"]}
         child = xml_element("video", children=None, attributes=attributes)
         return child
 
@@ -268,7 +265,7 @@ class OlxExport:
             # hence we need to convert the modified HTML back to string.
             for iframe in converted_iframes:
                 iframe.getparent().remove(iframe)
-            return html.tostring(parsed_html).decode('utf-8'), video_olx
+            return html.tostring(parsed_html).decode("utf-8"), video_olx
         return html_str, video_olx
 
     def _create_lti_node(self, details):

--- a/src/cc2olx/settings.py
+++ b/src/cc2olx/settings.py
@@ -45,6 +45,6 @@ def collect_settings(parsed_args):
         "output_format": parsed_args.result,
         "logging_config": logging_config,
         "workspace": Path.cwd() / "output",
-        "link_file": parsed_args.link_file
+        "link_file": parsed_args.link_file,
     }
     return settings

--- a/src/cc2olx/tools/README.rst
+++ b/src/cc2olx/tools/README.rst
@@ -29,7 +29,7 @@ In order to for this tool to run successfully, the following must be true of the
 * Each row in the file should describe a single video that appears in the directory supplied as a command line argument.
 * The CSV should contain a header row, labeling each column.
 * The first column should be labeled "Relative File Path". The values for this column should be the paths to the video files relative to the directory supplied as a command line argument. For example, if the directory is ``/Users/example/workspaces/videos`` and the video is located at ``/Users/example/workspaces/videos/unit_1/video_1.mp4``, the value of this cell should be ``unit_1/video_1.mp4``.
-* The CSV should contain the columns "External Video Link" and "Youtube ID". They can appear anywhere in the file as long as "Relative File Path" remains the first column.
+* The CSV should contain the columns "External Video Link" and "Youtube Id". They can appear anywhere in the file as long as "Relative File Path" remains the first column.
 * Empty values should be represented as empty cells. Do not use "NONE", "N/A", etc.
 
 Output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,7 @@ def video_upload_args(fixtures_data_dir):
         "output_csv": NamedTemporaryFile().name,
     }
 
+
 @pytest.fixture(scope="session")
 def link_map_csv(fixtures_data_dir):
     """
@@ -138,6 +139,6 @@ def iframe_content(fixtures_data_dir):
     """
 
     html_file_path = str(fixtures_data_dir / "imscc_file" / "iframe.html")
-    with open(html_file_path, 'r') as htmlcontent:
+    with open(html_file_path, "r") as htmlcontent:
         content = htmlcontent.read()
     return content

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,12 +15,7 @@ def test_parse_args(imscc_file):
         ]
     )
 
-    assert parsed_args == Namespace(
-        inputs=[imscc_file],
-        loglevel="INFO",
-        result="folder",
-        link_file=None
-    )
+    assert parsed_args == Namespace(inputs=[imscc_file], loglevel="INFO", result="folder", link_file=None)
 
 
 def test_parse_args_csv_file(imscc_file, link_map_csv):
@@ -28,16 +23,6 @@ def test_parse_args_csv_file(imscc_file, link_map_csv):
     Basic cli test with csv file parsed.
     """
 
-    parsed_args = parse_args([
-        "-i",
-        str(imscc_file),
-        "-f",
-        link_map_csv
-    ])
+    parsed_args = parse_args(["-i", str(imscc_file), "-f", link_map_csv])
 
-    assert parsed_args == Namespace(
-        inputs=[imscc_file],
-        loglevel="INFO",
-        result="folder",
-        link_file=link_map_csv
-    )
+    assert parsed_args == Namespace(inputs=[imscc_file], loglevel="INFO", result="folder", link_file=link_map_csv)

--- a/tests/test_kaltura_link_parser.py
+++ b/tests/test_kaltura_link_parser.py
@@ -75,7 +75,7 @@ class TestKalturaIframeLinkParse:
         # Example of video element
         # '<video edx_video_id="42d2a5e2-bced-45d6-b8dc-2f5901c9fdd0"/>\n'  # noqa: E501
         actual_video_olx = video_olx_list[0]
-        assert actual_video_olx.hasAttribute('edx_video_id')
+        assert actual_video_olx.hasAttribute("edx_video_id")
 
     def test_get_netlocation(self, iframe_link_parser):
         """

--- a/tests/test_link_file_reader.py
+++ b/tests/test_link_file_reader.py
@@ -24,10 +24,12 @@ class TestLinkMapReader:
         Args:
             link_map ([fixture]): Map of links to rows
         """
-        assert link_map['https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_9if7cth0/format/url/protocol/https'] == {  # noqa: E501
-            'Edx Id': '42d2a5e2-bced-45d6-b8dc-2f5901c9fdd1',
-            'External Video Link': 'https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_9if7cth0/format/url/protocol/https',  # noqa: E501
-            'Youtube Id': 'NXlG00JYX-o'
+        assert link_map[
+            "https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_9if7cth0/format/url/protocol/https"  # noqa: E501
+        ] == {
+            "Edx Id": "42d2a5e2-bced-45d6-b8dc-2f5901c9fdd1",
+            "External Video Link": "https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_9if7cth0/format/url/protocol/https",  # noqa: E501
+            "Youtube Id": "NXlG00JYX-o",
         }
 
     def test_read_csv_file(self, link_map_csv):

--- a/tests/test_olx.py
+++ b/tests/test_olx.py
@@ -83,6 +83,6 @@ class TestOlXExporeterIframeParser:
             iframe_content ([str]): Html file content.
         """
         olx_exporter = self._get_oxl_exporter(cartridge, link_map_csv)
-        nodes = olx_exporter._create_olx_nodes('html', {"html": iframe_content})
+        nodes = olx_exporter._create_olx_nodes("html", {"html": iframe_content})
         # Html xblock and video xblock
         assert len(nodes) == 2


### PR DESCRIPTION
I found that the tool that OpenCraft had written for converting embedded videos to video xblocks was expecting a "Youtube Id" column header.

Also ran `black` to reformat code so that travis formatting checks can pass.