### PR TITLE
[BD-27] [BB-3575] Existing Content Types - Common Cartridge v1.3 Support

### DIFF
--- a/src/cc2olx/models.py
+++ b/src/cc2olx/models.py
@@ -304,13 +304,13 @@ class Cartridge:
                 return None, None
 
         # Match any of imswl_xmlv1p1, imswl_xmlv1p2 etc
-        elif re.match(r'^imswl_xmlv\d+p\d+$', res_type):
+        elif re.match(r"^imswl_xmlv\d+p\d+$", res_type):
             tree = filesystem.get_xml_tree(self._res_filename(res["children"][0].href))
             root = tree.getroot()
             namespaces = {
-                'imswl_xmlv1p1': 'http://www.imsglobal.org/xsd/imsccv1p1/imswl_v1p1',
-                'imswl_xmlv1p2': 'http://www.imsglobal.org/xsd/imsccv1p2/imswl_v1p2',
-                'imswl_xmlv1p3': 'http://www.imsglobal.org/xsd/imsccv1p3/imswl_v1p3',
+                "imswl_xmlv1p1": "http://www.imsglobal.org/xsd/imsccv1p1/imswl_v1p1",
+                "imswl_xmlv1p2": "http://www.imsglobal.org/xsd/imsccv1p2/imswl_v1p2",
+                "imswl_xmlv1p3": "http://www.imsglobal.org/xsd/imsccv1p3/imswl_v1p3",
             }
             ns = {"wl": namespaces[res_type]}
             title = root.find("wl:title", ns).text
@@ -318,18 +318,18 @@ class Cartridge:
             return "link", {"href": url, "text": title}
 
         # Match any of imsbasiclti_xmlv1p0, imsbasiclti_xmlv1p3 etc
-        elif re.match(r'^imsbasiclti_xmlv\d+p\d+$', res_type):
+        elif re.match(r"^imsbasiclti_xmlv\d+p\d+$", res_type):
             data = self._parse_lti(res)
             return "lti", data
 
         # Match any of imsqti_xmlv1p2/imscc_xmlv1p1/assessment, imsqti_xmlv1p3/imscc_xmlv1p3/assessment etc
-        elif re.match(r'^imsqti_xmlv\d+p\d+/imscc_xmlv\d+p\d+/assessment$', res_type):
+        elif re.match(r"^imsqti_xmlv\d+p\d+/imscc_xmlv\d+p\d+/assessment$", res_type):
             res_filename = self._res_filename(res["children"][0].href)
             qti_parser = QtiParser(res_filename)
             return "qti", qti_parser.parse_qti()
 
         # Match any of imsdt_xmlv1p1, imsdt_xmlv1p2, imsdt_xmlv1p3 etc
-        elif re.match(r'^imsdt_xmlv\d+p\d+$', res_type):
+        elif re.match(r"^imsdt_xmlv\d+p\d+$", res_type):
             data = self._parse_discussion(res, res_type)
             return "discussion", data
 
@@ -672,9 +672,9 @@ class Cartridge:
         """
 
         namespaces = {
-            'imsdt_xmlv1p1': 'http://www.imsglobal.org/xsd/imsccv1p1/imsdt_v1p1',
-            'imsdt_xmlv1p2': 'http://www.imsglobal.org/xsd/imsccv1p2/imsdt_v1p2',
-            'imsdt_xmlv1p3': 'http://www.imsglobal.org/xsd/imsccv1p3/imsdt_v1p3',
+            "imsdt_xmlv1p1": "http://www.imsglobal.org/xsd/imsccv1p1/imsdt_v1p1",
+            "imsdt_xmlv1p2": "http://www.imsglobal.org/xsd/imsccv1p2/imsdt_v1p2",
+            "imsdt_xmlv1p3": "http://www.imsglobal.org/xsd/imsccv1p3/imsdt_v1p3",
         }
 
         data = {"dependencies": []}

--- a/src/cc2olx/models.py
+++ b/src/cc2olx/models.py
@@ -303,7 +303,7 @@ class Cartridge:
                 logger.info("Skipping webcontent: %s", res_filename)
                 return None, None
 
-        elif res_type == "imswl_xmlv1p1":
+        elif res_type in ["imswl_xmlv1p1", "imswl_xmlv1p2", "imswl_xmlv1p3"]:
             tree = filesystem.get_xml_tree(self._res_filename(res["children"][0].href))
             root = tree.getroot()
             ns = {"wl": "http://www.imsglobal.org/xsd/imsccv1p1/imswl_v1p1"}
@@ -311,16 +311,16 @@ class Cartridge:
             url = root.find("wl:url", ns).get("href")
             return "link", {"href": url, "text": title}
 
-        elif res_type == "imsbasiclti_xmlv1p0":
+        elif res_type in ["imsbasiclti_xmlv1p0", "imsbasiclti_xmlv1p3"]:
             data = self._parse_lti(res)
             return "lti", data
 
-        elif res_type == "imsqti_xmlv1p2/imscc_xmlv1p1/assessment":
+        elif res_type in ["imsqti_xmlv1p2/imscc_xmlv1p1/assessment", "imsqti_xmlv1p3/imscc_xmlv1p3/assessment"]:
             res_filename = self._res_filename(res["children"][0].href)
             qti_parser = QtiParser(res_filename)
             return "qti", qti_parser.parse_qti()
 
-        elif res_type == "imsdt_xmlv1p1":
+        elif res_type in ["imsdt_xmlv1p1", "imsdt_xmlv1p2", "imsdt_xmlv1p3"]:
             data = self._parse_discussion(res)
             return "discussion", data
 

--- a/tests/fixtures_data/imscc_file/imsmanifest.xml
+++ b/tests/fixtures_data/imscc_file/imsmanifest.xml
@@ -60,6 +60,9 @@
                     <item identifier="pdf_outside_resource" identifierref="pdf_dependency">
                         <title>PDF Outside of Web Resources</title>
                     </item>
+                    <item identifier="web_link_content" identifierref="resource_8_web_link_content">
+                        <title>Web Link Content</title>
+                    </item>
                 </item>
             </item>
         </organization>
@@ -111,6 +114,9 @@
         </resource>
         <resource identifier="pdf_dependency" type="webcontent">
             <file href="extra_files/example.pdf" />
+        </resource>
+        <resource identifier="resource_8_web_link_content" type="imswl_xmlv1p3">
+            <file href="web_link_content.xml"/>
         </resource>
     </resources>
 </manifest>

--- a/tests/fixtures_data/imscc_file/web_link_content.xml
+++ b/tests/fixtures_data/imscc_file/web_link_content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<webLink xmlns="http://www.imsglobal.org/xsd/imsccv1p3/imswl_v1p3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsccv1p3/imswl_v1p3 http://www.imsglobal.org/profile/cc/ccv1p3/ccv1p3_imswl_v1p3.xsd">
+    <title>Web Link Content</title>
+    <url href="http://web-link"/>
+</webLink>

--- a/tests/fixtures_data/studio_course_xml/course.xml
+++ b/tests/fixtures_data/studio_course_xml/course.xml
@@ -144,6 +144,9 @@
 			<vertical display_name="PDF Outside of Web Resources" url_name="">
 				<html display_name="PDF Outside of Web Resources" url_name="pdf_dependency"><![CDATA[<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"/></head><body><p><a href="/static/extra_files/example.pdf" alt="extra_files/example.pdf">extra_files/example.pdf<a></p></body></html>]]></html>
 			</vertical>
+			<vertical display_name="Web Link Content" url_name="">
+				<html display_name="Web Link Content" url_name="resource_8_web_link_content"><![CDATA[<a href='http://web-link'>Web Link Content</a>]]></html>
+			</vertical>
 		</sequential>
 	</chapter>
 </course>

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -37,7 +37,7 @@ def test_load_manifest_extracted(imscc_file, settings, temp_workspace_dir):
         "version": cartridge_version,
     }
 
-    assert len(cartridge.resources) == 11
+    assert len(cartridge.resources) == 12
     assert len(cartridge.resources[0]["children"]) == 6
     assert isinstance(cartridge.resources[0]["children"][0], ResourceFile)
 
@@ -148,6 +148,18 @@ def test_cartridge_normalize(imscc_file, settings):
                                 "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
                                 "identifierref": None,
                                 "title": "PDF Outside of Web Resources",
+                            },
+                            {
+                                "children": [
+                                    {
+                                        "identifier": "web_link_content",
+                                        "identifierref": "resource_8_web_link_content",
+                                        "title": "Web Link Content",
+                                    }
+                                ],
+                                "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                                "identifierref": None,
+                                "title": "Web Link Content",
                             },
                         ],
                         "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",


### PR DESCRIPTION
This PR adds support for Common Cartridge v1.3 - for existing content types. 
- Web Content
- Associated Content
- QTI Assessment (CC Profiles)
- Discussion Topic
- Web Links
- LTI Link

**JIRA tickets**: https://tasks.opencraft.com/browse/BB-3575

**Discussions**: N/A

**Dependencies**: None

**Screenshots**:  N/A

**Sandbox URL**: N/A

**Merge deadline**: None

**Testing instructions**:

1. Pull this PR
2. Convert a Common Cartridge V1.3 file to OLX
3. It should convert existing content types correctly

**Author notes and concerns**:

1. A refactor might be better to add support for different CC versions.

**Reviewers**
- [ ] @kaizoku
- [ ] edX reviewer[s] TBD
