### PR TITLE
[BD-27] [TNL-7891] [BB-3539] Remove Empty Sections from cc2olx Conversions

### DIFF
--- a/src/cc2olx/models.py
+++ b/src/cc2olx/models.py
@@ -130,6 +130,11 @@ class Cartridge:
             "structure": "rooted-hierarchy",
         }
         for section in sections:
+
+            # Skip if have no title or no children
+            if not section.get("title") or not section.get("children"):
+                continue
+
             if is_leaf(section):
                 # Structure is too shallow.
                 # Found leaf at section level.

--- a/tests/fixtures_data/imscc_file/imsmanifest.xml
+++ b/tests/fixtures_data/imscc_file/imsmanifest.xml
@@ -61,6 +61,7 @@
                         <title>PDF Outside of Web Resources</title>
                     </item>
                 </item>
+                <item identifier="empty_sequence"></item>
             </item>
         </organization>
     </organizations>

--- a/tests/fixtures_data/imscc_file/imsmanifest.xml
+++ b/tests/fixtures_data/imscc_file/imsmanifest.xml
@@ -62,6 +62,9 @@
                     </item>
                 </item>
                 <item identifier="empty_sequence"></item>
+                <item identifier="empty_sequence_with_title">
+                    <title>Empty Sequence</title>
+                </item>
             </item>
         </organization>
     </organizations>


### PR DESCRIPTION
This PR avoids adding sequences with no title (empty) to output OLX. Having sequences with no title breaks outline by creating an error when trying to remove them from Studio.

**JIRA tickets**: 
- https://tasks.opencraft.com/browse/BB-3539
- https://openedx.atlassian.net/browse/TNL-7891

**Discussions**: N/A

**Dependencies**: None

**Screenshots**: N/A

**Sandbox URL**: N/A

**Merge deadline**: None

**Testing instructions**:

1. Pull this PR.
2. Collect a ``imscc`` file with empty sequences. You can zip the test fixture ``imscc`` to create such file.
3. Convert using ``cc2olx``.
4. Import the output ``tar.gz`` file on your local devstack.
5. Check that empty sections have been excluded.

**Author notes and concerns**:

1. What if we have a sequence that has no title but has children? Can such a case arrive?

**Reviewers**
- [ ] @kaizoku
- [ ] edX reviewer[s] TBD