### PR TITLE
Updates to video upload and converter tools

### DIFF
--- a/src/cc2olx/iframe_link_parser.py
+++ b/src/cc2olx/iframe_link_parser.py
@@ -4,6 +4,12 @@ from cc2olx.link_file_reader import LinkFileReader
 from cc2olx.utils import element_builder
 
 
+class IframeLinkParserError(Exception):
+    """
+    Exception type for Iframe link parsing errors.
+    """
+
+
 class IframeLinkParser:
     """
     This class forms the base class for all type of link extractor that are being
@@ -91,13 +97,15 @@ class IframeLinkParser:
         """
         xml_element = element_builder(doc)
         attributes = {}
-        edx_id = url_row["Edx Id"]
-        youtube_id = url_row["Youtube Id"]
+        edx_id = url_row.get("Edx Id", "")
+        youtube_id = url_row.get("Youtube Id", "")
         if edx_id.strip() != "":
             attributes["edx_video_id"] = edx_id
         elif youtube_id.strip() != "":
             attributes["youtube"] = "1.00:" + youtube_id
             attributes["youtube_id_1_0"] = youtube_id
+        else:
+            raise IframeLinkParserError("Missing Edx Id or Youtube Id for video conversion.")
         child = xml_element("video", children=None, attributes=attributes)
         return child
 

--- a/src/cc2olx/tools/video_upload.py
+++ b/src/cc2olx/tools/video_upload.py
@@ -6,10 +6,10 @@ from pathlib import Path
 import requests
 from requests.auth import AuthBase
 
-# OAUTH_TOKEN_URL = "https://courses.edx.org/oauth2/access_token"
-# GENERATE_UPLOAD_LINK_BASE_URL = "https://studio.edx.org/generate_video_upload_link/"
-OAUTH_TOKEN_URL = "https://courses.stage.edx.org/oauth2/access_token"
-GENERATE_UPLOAD_LINK_BASE_URL = "https://studio.stage.edx.org/generate_video_upload_link/"
+OAUTH_TOKEN_URL = "https://courses.edx.org/oauth2/access_token"
+GENERATE_UPLOAD_LINK_BASE_URL = "https://studio.edx.org/generate_video_upload_link/"
+# OAUTH_TOKEN_URL = "https://courses.stage.edx.org/oauth2/access_token"
+# GENERATE_UPLOAD_LINK_BASE_URL = "https://studio.stage.edx.org/generate_video_upload_link/"
 VIDEO_EXTENSION_CONTENT_TYPES = {
     ".mp4": "video/mp4",
     ".mov": "video/quicktime",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,51 @@ def link_map_csv(fixtures_data_dir):
 
 
 @pytest.fixture(scope="session")
+def link_map_edx_only_csv(fixtures_data_dir):
+    """
+        This fixture helps to provide csv file path to a csv containing only the edX Id
+    Args:
+        fixtures_data_dir ([str]): Path to the directory where fixture data is present.
+
+    Returns:
+        [str]: Path to the csv
+    """
+
+    link_map_csv_file_path = str(fixtures_data_dir / "link_map_edx_only.csv")
+    return link_map_csv_file_path
+
+
+@pytest.fixture(scope="session")
+def link_map_youtube_only_csv(fixtures_data_dir):
+    """
+        This fixture helps to provide csv file path to a csv containing only the youtube Id
+    Args:
+        fixtures_data_dir ([str]): Path to the directory where fixture data is present.
+
+    Returns:
+        [str]: Path to the csv
+    """
+
+    link_map_csv_file_path = str(fixtures_data_dir / "link_map_youtube_only.csv")
+    return link_map_csv_file_path
+
+
+@pytest.fixture(scope="session")
+def link_map_bad_csv(fixtures_data_dir):
+    """
+        This fixture helps to provide csv file path containing neither edX nor youtube Id
+    Args:
+        fixtures_data_dir ([str]): Path to the directory where fixture data is present.
+
+    Returns:
+        [str]: Path to the csv
+    """
+
+    link_map_csv_file_path = str(fixtures_data_dir / "link_map_bad.csv")
+    return link_map_csv_file_path
+
+
+@pytest.fixture(scope="session")
 def iframe_content(fixtures_data_dir):
     """
         This fixture gives out the html content of the file.

--- a/tests/fixtures_data/link_map_bad.csv
+++ b/tests/fixtures_data/link_map_bad.csv
@@ -1,0 +1,6 @@
+External Video Link
+https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_zeqnrfgw/format/url/protocol/https
+https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_9if7cth0/format/url/protocol/https
+https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_c7j5va21/format/url/protocol/https
+https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_xcjzc0q5/format/url/protocol/https
+https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_t1jur7p3/format/url/protocol/https

--- a/tests/fixtures_data/link_map_edx_only.csv
+++ b/tests/fixtures_data/link_map_edx_only.csv
@@ -1,0 +1,6 @@
+External Video Link,Edx Id
+https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_zeqnrfgw/format/url/protocol/https,42d2a5e2-bced-45d6-b8dc-2f5901c9fdd0
+https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_9if7cth0/format/url/protocol/https,42d2a5e2-bced-45d6-b8dc-2f5901c9fdd1
+https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_c7j5va21/format/url/protocol/https,42d2a5e2-bced-45d6-b8dc-2f5901c9fdd2
+https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_xcjzc0q5/format/url/protocol/https,42d2a5e2-bced-45d6-b8dc-2f5901c9fdd3
+https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_t1jur7p3/format/url/protocol/https,42d2a5e2-bced-45d6-b8dc-2f5901c9fdd4

--- a/tests/fixtures_data/link_map_youtube_only.csv
+++ b/tests/fixtures_data/link_map_youtube_only.csv
@@ -1,0 +1,6 @@
+External Video Link,Youtube Id
+https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_zeqnrfgw/format/url/protocol/https,onRUvL2SBG8
+https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_9if7cth0/format/url/protocol/https,NXlG00JYX-o
+https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_c7j5va21/format/url/protocol/https,_SIvUj7xUKc
+https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_xcjzc0q5/format/url/protocol/https,3pT8dh4ftbc
+https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_t1jur7p3/format/url/protocol/https,uwuZKEKpq8k

--- a/tests/test_kaltura_link_parser.py
+++ b/tests/test_kaltura_link_parser.py
@@ -116,3 +116,39 @@ class TestKalturaIframeLinkParse:
         extracted_url = iframe_link_parser._extract_url(url)
         expected_url = "https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_mdkfwzpg/format/url/protocol/https"  # noqa: E501
         assert extracted_url == expected_url
+
+    def test_video_olx_edx_id_only(self, iframes, link_map_edx_only_csv):
+        """
+        Test that video olx is generated and produced when only edX Id is supplied
+        """
+        iframe_link_parser = KalturaIframeLinkParser(link_map_edx_only_csv)
+        doc = xml.dom.minidom.Document()
+        video_olx, _ = iframe_link_parser.get_video_olx(doc, iframes)
+
+        assert len(video_olx) == 1
+
+        actual_video_olx = video_olx[0]
+        assert actual_video_olx.hasAttribute("edx_video_id")
+
+    def test_video_olx_youtube_id_only(self, iframes, link_map_youtube_only_csv):
+        """
+        Test that video olx is generated and produced when only Youtube Id is supplied
+        """
+        iframe_link_parser = KalturaIframeLinkParser(link_map_youtube_only_csv)
+        doc = xml.dom.minidom.Document()
+        video_olx, _ = iframe_link_parser.get_video_olx(doc, iframes)
+
+        assert len(video_olx) == 1
+
+        actual_video_olx = video_olx[0]
+        assert actual_video_olx.hasAttribute("youtube")
+
+    def test_video_olx_bad_link_map(self, iframes, link_map_bad_csv):
+        """
+        Test that error is raised when youtube Id or edX Id are not provided
+        """
+        iframe_link_parser = KalturaIframeLinkParser(link_map_bad_csv)
+        doc = xml.dom.minidom.Document()
+
+        with pytest.raises(Exception):
+            video_olx, _ = iframe_link_parser.get_video_olx(doc, iframes)


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

- Updated urls for video upload tool to point to prod as opposed to stage
- Allow user to only supply one of edX or Youtube Id in the video csv file provided. Previously this would raise an exception if a youtube ID was not provided, now it only raises an exception when neither the Youtube nor edX Id are present