### PR TITLE
[BD-27][TNL-7891][BB-3539] Remove Empty Sections from cc2olx Conversions - ContextModuleSubHeader

### DIFF
--- a/src/cc2olx/models.py
+++ b/src/cc2olx/models.py
@@ -15,7 +15,7 @@ MANIFEST = "imsmanifest.xml"
 # canvas-cc course settings
 COURSE_SETTINGS_DIR = "course_settings"
 MODULE_META = "module_meta.xml"
-CANVAS_REPORT = 'canvas_export.txt'
+CANVAS_REPORT = "canvas_export.txt"
 
 DIFFUSE_SHALLOW_SECTIONS = False
 DIFFUSE_SHALLOW_SUBSECTIONS = True

--- a/tests/fixtures_data/imscc_file/course_settings/module_meta.xml
+++ b/tests/fixtures_data/imscc_file/course_settings/module_meta.xml
@@ -37,4 +37,56 @@
             </item>
         </items>
     </module>
+    <module identifier="sequence2">
+        <title>Sequence2</title>
+        <workflow_state>active</workflow_state>
+        <position>2</position>
+        <require_sequential_progress>false</require_sequential_progress>
+        <locked>false</locked>
+        <items>
+            <item identifier="vertical1">
+                <content_type>Webcontent</content_type>
+                <workflow_state>active</workflow_state>
+                <title>Vertical</title>
+                <identifierref>resource_3_vertical</identifierref>
+                <position>1</position>
+                <new_tab/>
+                <indent>0</indent>
+            </item>
+            <item identifier="subheader1">
+                <content_type>ContextModuleSubHeader</content_type>
+                <workflow_state>active</workflow_state>
+                <title>Sub Header 1</title>
+                <position>2</position>
+                <new_tab>false</new_tab>
+                <indent>0</indent>
+            </item>
+            <item identifier="subheader1_vertical">
+                <content_type>Webcontent</content_type>
+                <workflow_state>active</workflow_state>
+                <title>Vertical</title>
+                <identifierref>resource_3_vertical</identifierref>
+                <position>3</position>
+                <new_tab/>
+                <indent>0</indent>
+            </item>
+            <item identifier="subheader2">
+                <content_type>ContextModuleSubHeader</content_type>
+                <workflow_state>active</workflow_state>
+                <title>Sub Header 1</title>
+                <position>4</position>
+                <new_tab>false</new_tab>
+                <indent>0</indent>
+            </item>
+            <item identifier="subheader2_vertical">
+                <content_type>Webcontent</content_type>
+                <workflow_state>active</workflow_state>
+                <title>Vertical</title>
+                <identifierref>resource_3_vertical</identifierref>
+                <position>5</position>
+                <new_tab/>
+                <indent>0</indent>
+            </item>
+        </items>
+    </module>
 </modules>

--- a/tests/fixtures_data/imscc_file/imsmanifest.xml
+++ b/tests/fixtures_data/imscc_file/imsmanifest.xml
@@ -61,6 +61,24 @@
                         <title>PDF Outside of Web Resources</title>
                     </item>
                 </item>
+                <item identifier="sequence2">
+                    <title>Sequence2</title>
+                    <item identifier="vertical1" identifierref="resource_3_vertical">
+                        <title>Vertical</title>
+                    </item>
+                    <item identifier="subheader1">
+                        <title>Sub Header 1</title>
+                    </item>
+                    <item identifier="subheader1_vertical" identifierref="resource_3_vertical">
+                        <title>Vertical</title>
+                    </item>
+                    <item identifier="subheader2">
+                        <title>Sub Header 2</title>
+                    </item>
+                    <item identifier="subheader2_vertical" identifierref="resource_3_vertical">
+                        <title>Vertical</title>
+                    </item>
+                </item>
             </item>
         </organization>
     </organizations>

--- a/tests/fixtures_data/studio_course_xml/course.xml
+++ b/tests/fixtures_data/studio_course_xml/course.xml
@@ -146,4 +146,60 @@
 			</vertical>
 		</sequential>
 	</chapter>
+	<chapter display_name="Sequence2" url_name="">
+		<sequential display_name="Vertical" url_name="resource_3_vertical">
+			<vertical display_name="Vertical" url_name="resource_3_vertical">
+				<html display_name="Vertical" url_name="resource_3_vertical"><![CDATA[<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<title>Vertical</title>
+<meta name="identifier" content="resource_3_vertical"/>
+<meta name="editing_roles" content="teachers"/>
+<meta name="workflow_state" content="active"/>
+</head>
+<body>
+<img src="/static/QuizImages/fractal.jpg" alt="fractal.jpg" width="500" height="375" />
+<p>Fractal Image <a href="/static/QuizImages/fractal.jpg?canvas_download=1" target="_blank">Fractal Image</a></p>
+</body>
+</html>
+]]></html>
+			</vertical>
+		</sequential>
+		<sequential display_name="Sub Header 1" url_name="">
+			<vertical display_name="Vertical" url_name="">
+				<html display_name="Vertical" url_name="resource_3_vertical"><![CDATA[<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<title>Vertical</title>
+<meta name="identifier" content="resource_3_vertical"/>
+<meta name="editing_roles" content="teachers"/>
+<meta name="workflow_state" content="active"/>
+</head>
+<body>
+<img src="/static/QuizImages/fractal.jpg" alt="fractal.jpg" width="500" height="375" />
+<p>Fractal Image <a href="/static/QuizImages/fractal.jpg?canvas_download=1" target="_blank">Fractal Image</a></p>
+</body>
+</html>
+]]></html>
+			</vertical>
+		</sequential>
+		<sequential display_name="Sub Header 2" url_name="">
+			<vertical display_name="Vertical" url_name="">
+				<html display_name="Vertical" url_name="resource_3_vertical"><![CDATA[<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<title>Vertical</title>
+<meta name="identifier" content="resource_3_vertical"/>
+<meta name="editing_roles" content="teachers"/>
+<meta name="workflow_state" content="active"/>
+</head>
+<body>
+<img src="/static/QuizImages/fractal.jpg" alt="fractal.jpg" width="500" height="375" />
+<p>Fractal Image <a href="/static/QuizImages/fractal.jpg?canvas_download=1" target="_blank">Fractal Image</a></p>
+</body>
+</html>
+]]></html>
+			</vertical>
+		</sequential>
+	</chapter>
 </course>

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -158,7 +158,71 @@ def test_cartridge_normalize(imscc_file, settings):
                 "identifier": "sequence",
                 "identifierref": None,
                 "title": "Sequence",
-            }
+            },
+            {
+                "children": [
+                    {
+                        "children": [
+                            {
+                                "children": [
+                                    {
+                                        "identifier": "vertical1",
+                                        "identifierref": "resource_3_vertical",
+                                        "title": "Vertical",
+                                    }
+                                ],
+                                "identifier": "vertical1",
+                                "identifierref": "resource_3_vertical",
+                                "title": "Vertical",
+                            }
+                        ],
+                        "identifier": "vertical1",
+                        "identifierref": "resource_3_vertical",
+                        "title": "Vertical",
+                    },
+                    {
+                        "children": [
+                            {
+                                "children": [
+                                    {
+                                        "identifier": "subheader1_vertical",
+                                        "identifierref": "resource_3_vertical",
+                                        "title": "Vertical",
+                                    }
+                                ],
+                                "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                                "identifierref": None,
+                                "title": "Vertical",
+                            }
+                        ],
+                        "identifier": "subheader1",
+                        "identifierref": None,
+                        "title": "Sub Header 1",
+                    },
+                    {
+                        "children": [
+                            {
+                                "children": [
+                                    {
+                                        "identifier": "subheader2_vertical",
+                                        "identifierref": "resource_3_vertical",
+                                        "title": "Vertical",
+                                    }
+                                ],
+                                "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                                "identifierref": None,
+                                "title": "Vertical",
+                            }
+                        ],
+                        "identifier": "subheader2",
+                        "identifierref": None,
+                        "title": "Sub Header 2",
+                    },
+                ],
+                "identifier": "sequence2",
+                "identifierref": None,
+                "title": "Sequence2",
+            },
         ],
         "identifier": "org_1",
         "structure": "rooted-hierarchy",


### PR DESCRIPTION
This PR fixes an issue related to empty sections while there are ``canvas`` items with content type ``ContextModuleSubHeader``. With this PR, ``cc2olx`` will treat these types of items as ``subsections`` and collapse related (consecutive) items under it as ``verticals``.

**JIRA tickets**: 
- https://tasks.opencraft.com/browse/BB-3539
- https://openedx.atlassian.net/browse/TNL-7891

~~**Discussions**:~~

**Dependencies**: None

~~**Screenshots**:~~

~~**Sandbox URL**:~~

**Merge deadline**: None

**Testing instructions**:

1. Pull this PR.
2. Find a canvas ``imscc`` file that contains ``ContextModuleSubHeader``, you can use the updated fixture with this PR.
3. Convert using ``cc2olx``. 
4. Check that item after ``ContextModuleSubHeader`` collapsed into it as verticals.

**Author notes and concerns**:
N/A

**Reviewers**
- [ ] @kaizoku
- [ ] edX reviewer[s] TBD
