### PR TITLE
[BD-27] [TNL-7950] Make url_name of openassessment element unique

### DIFF
--- a/src/cc2olx/qti.py
+++ b/src/cc2olx/qti.py
@@ -282,6 +282,7 @@ class QtiExport:
                 ])
             ],
             {
+                'url_name': problem_data['ident'],
                 'text_response': 'required',
                 'prompts_type': 'html'
             }
@@ -324,12 +325,15 @@ class QtiParser:
 
         parsed_problems = []
 
-        for problem in problems:
+        for i, problem in enumerate(problems):
             data = {}
 
             attributes = problem.attrib
 
-            data["ident"] = attributes["ident"]
+            # We're adding unique string to identifier here to handle cases,
+            # when we're getting malformed course (due to a weird Canvas behaviour)
+            # with equal identifiers. LMS doesn't support blocks with the same identifiers.
+            data["ident"] = attributes["ident"] + str(i)
             data["title"] = attributes["title"]
 
             cc_profile = self._parse_problem_profile(problem)


### PR DESCRIPTION
This PR makes "url_name" attribute of `<openassesment/>` unique. When there are a few such elements with the same value of this attribute — LMS shows multiple copies of the last one instead of showing different ORA blocks. 

**JIRA tickets**:
- [BB-3681](https://tasks.opencraft.com/browse/BB-3681)
- [TNL-7950](https://openedx.atlassian.net/browse/TNL-7950)
- [BLENDED-770](https://openedx.atlassian.net/browse/BLENDED-770)

**Testing instructions**:

TBA

**Author notes and concerns**:

1. Convert course, for which issue was reported.
2. Upload it to LMS.
3. Make sure that ORA blocks are different.

**Reviewers**
- [ ] @kaizoku  
- [ ] @alangsto 
