### PR TITLE
Fix Essay Solution Parsing and Add Basic Essay Problem Response Processing

### DIFF
--- a/src/cc2olx/qti.py
+++ b/src/cc2olx/qti.py
@@ -19,6 +19,7 @@ FILL_IN_THE_BLANK = "cc.fib.v0p1"
 ESSAY = "cc.essay.v0p1"
 BOOLEAN = "cc.true_false.v0p1"
 PATTERN_MATCH = "cc.pattern_match.v0p1"
+RESPROCESSING_TYPES = ["general_fb", "correct_fb", "general_incorrect_fb"]
 
 
 class QtiError(Exception):
@@ -220,6 +221,43 @@ class QtiExport:
 
         el = element_builder(self.doc)
 
+        if any(key in RESPROCESSING_TYPES for key in problem_data.keys()):
+            resp_samples = [
+                el("name", "Feedback"),
+                el("label", "Feedback"),
+                el("prompt", "Example Feedback"),
+            ]
+
+            for desc, key in zip(["General", "Correct", "Incorrect"], RESPROCESSING_TYPES):
+                resp_samples.append(
+                    el(
+                        "option",
+                        [el("name", desc), el("label", desc), el("explanation", problem_data.get(key, desc))],
+                        {"points": "0"},
+                    )
+                )
+            criterion = el("criterion", resp_samples, {"feedback": "optional"})
+        else:
+            criterion = el(
+                "criterion",
+                [
+                    el("name", "Ideas"),
+                    el("label", "Ideas"),
+                    el("prompt", "Example criterion"),
+                    el(
+                        "option",
+                        [el("name", "Poor"), el("label", "Poor"), el("explanation", "Explanation")],
+                        {"points": "0"},
+                    ),
+                    el(
+                        "option",
+                        [el("name", "Good"), el("label", "Good"), el("explanation", "Explanation")],
+                        {"points": "1"},
+                    ),
+                ],
+                {"feedback": "optional"},
+            )
+
         # fmt: off
         ora = el(
             'openassessment',
@@ -238,21 +276,7 @@ class QtiExport:
                     ])
                 ]),
                 el('rubric', [
-                    el('criterion', [
-                        el('name', 'Ideas'),
-                        el('label', 'Ideas'),
-                        el('prompt', 'Example criterion'),
-                        el('option', [
-                            el('name', 'Poor'),
-                            el('label', 'Poor'),
-                            el('explanation', 'Explanation')
-                        ], {'points': '0'}),
-                        el('option', [
-                            el('name', 'Good'),
-                            el('label', 'Good'),
-                            el('explanation', 'Explanation')
-                        ], {'points': '1'})
-                    ], {'feedback': "optional"}),
+                    criterion,
                     el('feedbackprompt', 'Feedback prompt text'),
                     el('feedback_default_text', 'Feedback prompt default text'),
                 ])
@@ -547,15 +571,27 @@ class QtiParser:
 
         data = {}
         presentation = problem.find("qti:presentation", self.NS)
+        itemfeedback = problem.find("qti:itemfeedback", self.NS)
         solution = problem.find("qti:itemfeedback/qti:solution", self.NS)
 
         data["problem_description"] = presentation.find("qti:material/qti:mattext", self.NS).text
 
-        if solution:
+        if solution is not None:
             sample_solution_selector = "qti:solutionmaterial/qti:material/qti:mattext"
             data["sample_solution"] = solution.find(sample_solution_selector, self.NS).text
 
+        if itemfeedback is not None:
+            for resp_type in RESPROCESSING_TYPES:
+                response_text = self._essay_response_processing(problem, resp_type)
+                if response_text:
+                    data[resp_type] = response_text
         return data
+
+    def _essay_response_processing(self, problem, resp_type):
+        respconditions = problem.find("qti:resprocessing/qti:respcondition", self.NS)
+        if respconditions.find(f"qti:displayfeedback[@linkrefid='{resp_type}']", self.NS) is not None:
+            text_selector = f"qti:itemfeedback[@ident='{resp_type}']/qti:flow_mat/qti:material/qti:mattext"
+            return problem.find(text_selector, self.NS).text
 
     def _parse_pattern_match_problem(self, problem):
         raise NotImplementedError

--- a/src/cc2olx/qti.py
+++ b/src/cc2olx/qti.py
@@ -547,12 +547,14 @@ class QtiParser:
 
         data = {}
         presentation = problem.find("qti:presentation", self.NS)
-        itemfeedback = problem.find("qti:itemfeedback", self.NS)
+        solution = problem.find("qti:itemfeedback/qti:solution", self.NS)
 
         data["problem_description"] = presentation.find("qti:material/qti:mattext", self.NS).text
-        if itemfeedback is not None:
-            sample_solution_selector = "qti:solution/qti:solutionmaterial/qti:material/qti:mattext"
-            data["sample_solution"] = itemfeedback.find(sample_solution_selector, self.NS).text
+
+        if solution:
+            sample_solution_selector = "qti:solutionmaterial/qti:material/qti:mattext"
+            data["sample_solution"] = solution.find(sample_solution_selector, self.NS).text
+
         return data
 
     def _parse_pattern_match_problem(self, problem):

--- a/tests/fixtures_data/imscc_file/resource_4_qti/assessment_qti.xml
+++ b/tests/fixtures_data/imscc_file/resource_4_qti/assessment_qti.xml
@@ -276,6 +276,53 @@
                     </solution>
                 </itemfeedback>
             </item>
+            <item ident="essay_question_2_id" title="Question">
+                <itemmetadata>
+                    <qtimetadata>
+                        <qtimetadatafield>
+                            <fieldlabel>cc_profile</fieldlabel>
+                            <fieldentry>cc.essay.v0p1</fieldentry>
+                        </qtimetadatafield>
+                        <qtimetadatafield>
+                            <fieldlabel>qmd_computerscored</fieldlabel>
+                            <fieldentry>No</fieldentry>
+                        </qtimetadatafield>
+                    </qtimetadata>
+                </itemmetadata>
+                <presentation>
+                    <material>
+                        <mattext texttype="text/html">&lt;div&gt;Did this course fulfill your needs?&lt;/div&gt;</mattext>
+                    </material>
+                    <response_str ident="response1" rcardinality="Single">
+                        <render_fib>
+                            <response_label ident="answer1" rshuffle="No" />
+                        </render_fib>
+                    </response_str>
+                </presentation>
+                <resprocessing>
+                    <outcomes>
+                        <decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal" />
+                    </outcomes>
+                    <respcondition continue="Yes">
+                        <conditionvar>
+                            <other />
+                        </conditionvar>
+                        <displayfeedback feedbacktype="Response" linkrefid="general_fb"/>
+                    </respcondition>
+                    <respcondition continue="No">
+                        <conditionvar>
+                            <other />
+                        </conditionvar>
+                    </respcondition>
+                </resprocessing>
+                <itemfeedback ident="general_fb">
+                    <flow_mat>
+                        <material>
+                            <mattext texttype="text/html">Sample Answer</mattext>
+                        </material>
+                    </flow_mat>
+                </itemfeedback>
+            </item>
         </section>
     </assessment>
 </questestinterop>

--- a/tests/fixtures_data/studio_course_xml/course.xml
+++ b/tests/fixtures_data/studio_course_xml/course.xml
@@ -103,6 +103,41 @@
 						<feedback_default_text>Feedback prompt default text</feedback_default_text>
 					</rubric>
 				</openassessment>
+				<openassessment text_response="required" prompts_type="html" display_name="QTI" url_name="resource_4_qti">
+					<title>Open Response Assessment</title>
+					<assessments>
+						<assessment name="staff-assessment" required="True"/>
+					</assessments>
+					<prompts>
+						<prompt>
+							<description>&lt;div&gt;Did this course fulfill your needs?&lt;/div&gt;</description>
+						</prompt>
+					</prompts>
+					<rubric>
+						<criterion feedback="optional">
+							<name>Feedback</name>
+							<label>Feedback</label>
+							<prompt>Example Feedback</prompt>
+							<option points="0">
+								<name>General</name>
+								<label>General</label>
+								<explanation>Sample Answer</explanation>
+							</option>
+							<option points="0">
+								<name>Correct</name>
+								<label>Correct</label>
+								<explanation>Correct</explanation>
+							</option>
+							<option points="0">
+								<name>Incorrect</name>
+								<label>Incorrect</label>
+								<explanation>Incorrect</explanation>
+							</option>
+						</criterion>
+						<feedbackprompt>Feedback prompt text</feedbackprompt>
+						<feedback_default_text>Feedback prompt default text</feedback_default_text>
+					</rubric>
+				</openassessment>
 			</vertical>
 			<vertical display_name="Discussion" url_name="">
 				<html display_name="Discussion" url_name="discussion_topic"><![CDATA[<p style="text-align: center;"><span style="color: #000080; font-size: 18pt;">Math Journal</span><br>Is 70 thousand written in standard form or<br>word form? Explain.</p>]]></html>


### PR DESCRIPTION
This PR updates the method of parsing example solutions for Common Cartridge essay problems (cc.essay.v0p1) to be more specific as some Common Cartridge authoring software uses this field slightly differently.
It also adds basic response processing support for essay problems based around how Canvas generates example text for essay type problems. This fills in the ORA rubric's criterion fields with correct, incorrect, and general feedback fields to be referenced when performing assessments in the ORA review process.

**JIRA tickets**: Implements TNL-8016, BB-3863.

**Discussions**: Discussed in meetings and via email chains

**Dependencies**: None

**Merge deadline**: ASAP

**Testing instructions**:

1. Convert Common Cartridge using an essay type problem with example responses
2. Check that ORA criterion are filled from the example responses in the Common Cartridge fields

**Author notes and concerns**:

1. This only implements basic response processing for essay types based on how Canvas fills in these fields
2. If we simply want to fix the issue seen, the first commit (f768c31016539697591c860805dbc6fb7f36cf2b) will be sufficient

**Reviewers**
- [ ] @farhaanbukhsh
- [ ] @alangsto
