### PR TITLE
python requirements update

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,9 +10,9 @@ chardet==4.0.0
     # via requests
 idna==2.10
     # via requests
-lxml==4.6.2
+lxml==4.6.3
     # via -r requirements/base.in
 requests==2.25.1
     # via -r requirements/base.in
-urllib3==1.26.3
+urllib3==1.26.4
     # via requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,6 +10,3 @@
 
 # Version 2 requires Python 3.5
 zipp==1.2.0
-
-# Needed as long as tox constrains this to <2
-importlib_metadata<2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -25,8 +25,6 @@ certifi==2020.12.5
     #   -r requirements/quality.txt
     #   -r requirements/travis.txt
     #   requests
-cffi==1.14.5
-    # via cryptography
 chardet==4.0.0
     # via
     #   -r requirements/quality.txt
@@ -42,14 +40,12 @@ codecov==2.1.11
     # via -r requirements/travis.txt
 colorama==0.4.4
     # via twine
-coverage==5.4
+coverage==5.5
     # via
     #   -r requirements/quality.txt
     #   -r requirements/travis.txt
     #   codecov
     #   pytest-cov
-cryptography==3.4.6
-    # via secretstorage
 distlib==0.3.1
     # via
     #   -r requirements/travis.txt
@@ -61,24 +57,24 @@ filelock==3.0.12
     #   -r requirements/travis.txt
     #   tox
     #   virtualenv
-flake8==3.8.4
+flake8==3.9.0
     # via -r requirements/quality.txt
 idna==2.10
     # via
     #   -r requirements/quality.txt
     #   -r requirements/travis.txt
     #   requests
+importlib-metadata==3.7.3
+    # via
+    #   keyring
+    #   twine
 iniconfig==1.1.1
     # via
     #   -r requirements/quality.txt
     #   pytest
-jeepney==0.6.0
-    # via
-    #   keyring
-    #   secretstorage
-keyring==22.0.1
+keyring==23.0.1
     # via twine
-lxml==4.6.2
+lxml==4.6.3
     # via -r requirements/quality.txt
 mccabe==0.6.1
     # via
@@ -99,7 +95,11 @@ pathspec==0.8.1
     # via
     #   -r requirements/quality.txt
     #   black
-pip-tools==5.5.0
+pep517==0.10.0
+    # via
+    #   -r requirements/pip-tools.txt
+    #   pip-tools
+pip-tools==6.0.1
     # via -r requirements/pip-tools.txt
 pkginfo==1.7.0
     # via twine
@@ -115,17 +115,15 @@ py==1.10.0
     #   -r requirements/travis.txt
     #   pytest
     #   tox
-pycodestyle==2.6.0
+pycodestyle==2.7.0
     # via
     #   -r requirements/quality.txt
     #   flake8
-pycparser==2.20
-    # via cffi
-pyflakes==2.2.0
+pyflakes==2.3.1
     # via
     #   -r requirements/quality.txt
     #   flake8
-pygments==2.8.0
+pygments==2.8.1
     # via readme-renderer
 pyparsing==2.4.7
     # via
@@ -143,7 +141,7 @@ pytest==6.2.2
     #   pytest-mock
 readme-renderer==29.0
     # via twine
-regex==2020.11.13
+regex==2021.3.17
     # via
     #   -r requirements/quality.txt
     #   black
@@ -158,8 +156,6 @@ requests==2.25.1
     #   twine
 rfc3986==1.4.0
     # via twine
-secretstorage==3.3.1
-    # via keyring
 six==1.15.0
     # via
     #   -r requirements/travis.txt
@@ -169,16 +165,18 @@ six==1.15.0
     #   virtualenv
 toml==0.10.2
     # via
+    #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   -r requirements/travis.txt
     #   black
+    #   pep517
     #   pytest
     #   tox
-tox==3.22.0
+tox==3.23.0
     # via -r requirements/travis.txt
-tqdm==4.57.0
+tqdm==4.59.0
     # via twine
-twine==3.3.0
+twine==3.4.1
     # via -r requirements/dev.in
 typed-ast==1.4.2
     # via
@@ -188,12 +186,12 @@ typing-extensions==3.7.4.3
     # via
     #   -r requirements/quality.txt
     #   black
-urllib3==1.26.3
+urllib3==1.26.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/travis.txt
     #   requests
-virtualenv==20.4.2
+virtualenv==20.4.3
     # via
     #   -r requirements/travis.txt
     #   tox
@@ -203,7 +201,10 @@ wheel==0.36.2
     # via -r requirements/dev.in
 xmlformatter==0.2.2
     # via -r requirements/quality.txt
+zipp==1.2.0
+    # via
+    #   -c requirements/constraints.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip
-# setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,8 +6,12 @@
 #
 click==7.1.2
     # via pip-tools
-pip-tools==5.5.0
+pep517==0.10.0
+    # via pip-tools
+pip-tools==6.0.1
     # via -r requirements/pip-tools.in
+toml==0.10.2
+    # via pep517
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -22,11 +22,11 @@ chardet==4.0.0
     #   requests
 click==7.1.2
     # via black
-coverage==5.4
+coverage==5.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-flake8==3.8.4
+flake8==3.9.0
     # via -r requirements/quality.in
 idna==2.10
     # via
@@ -36,7 +36,7 @@ iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
-lxml==4.6.2
+lxml==4.6.3
     # via -r requirements/test.txt
 mccabe==0.6.1
     # via flake8
@@ -56,9 +56,9 @@ py==1.10.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pycodestyle==2.6.0
+pycodestyle==2.7.0
     # via flake8
-pyflakes==2.2.0
+pyflakes==2.3.1
     # via flake8
 pyparsing==2.4.7
     # via
@@ -73,7 +73,7 @@ pytest==6.2.2
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-mock
-regex==2020.11.13
+regex==2021.3.17
     # via black
 requests==2.25.1
     # via -r requirements/test.txt
@@ -86,7 +86,7 @@ typed-ast==1.4.2
     # via black
 typing-extensions==3.7.4.3
     # via black
-urllib3==1.26.3
+urllib3==1.26.4
     # via
     #   -r requirements/test.txt
     #   requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,7 +14,7 @@ chardet==4.0.0
     # via
     #   -r requirements/base.txt
     #   requests
-coverage==5.4
+coverage==5.5
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -24,7 +24,7 @@ idna==2.10
     #   requests
 iniconfig==1.1.1
     # via pytest
-lxml==4.6.2
+lxml==4.6.3
     # via -r requirements/base.txt
 packaging==20.9
     # via pytest
@@ -47,7 +47,7 @@ requests==2.25.1
     # via -r requirements/base.txt
 toml==0.10.2
     # via pytest
-urllib3==1.26.3
+urllib3==1.26.4
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -12,7 +12,7 @@ chardet==4.0.0
     # via requests
 codecov==2.1.11
     # via -r requirements/travis.in
-coverage==5.4
+coverage==5.5
     # via
     #   -r requirements/travis.in
     #   codecov
@@ -40,9 +40,9 @@ six==1.15.0
     #   virtualenv
 toml==0.10.2
     # via tox
-tox==3.22.0
+tox==3.23.0
     # via -r requirements/travis.in
-urllib3==1.26.3
+urllib3==1.26.4
     # via requests
-virtualenv==20.4.2
+virtualenv==20.4.3
     # via tox


### PR DESCRIPTION
The automated upgrade task https://build.testeng.edx.org/job/cc2olx-upgrade-python-requirements/20/console failed due to a conflict with the constrained version of `importlib_metadata`. This constraint is no longer required, so removing it resolves the issue. 