### PR TITLE
[BD-27] [TNL-8046] Add module meta and handler for external_tools links

### DIFF
--- a/src/cc2olx/cli.py
+++ b/src/cc2olx/cli.py
@@ -52,4 +52,14 @@ def parse_args(args=None):
             "The header for the file should have External Video Link, Edx Id, Youtube Id"
         ),
     )
+    parser.add_argument(
+        "-p",
+        "--passport-file",
+        default=None,
+        help=(
+            "Path for CSV file which contins the LTI Consumer Id, "
+            "LTI Consumer Key and LTI Consumer Secret. The header for the file "
+            "should contain consumer_id, consumer_key and consumer_secret."
+        ),
+    )
     return parser.parse_args(args)

--- a/src/cc2olx/external/canvas/__init__.py
+++ b/src/cc2olx/external/canvas/__init__.py
@@ -1,0 +1,6 @@
+from .module_meta import ModuleMeta
+
+
+__all__ = [
+    "ModuleMeta",
+]

--- a/src/cc2olx/external/canvas/module_meta.py
+++ b/src/cc2olx/external/canvas/module_meta.py
@@ -1,0 +1,74 @@
+import logging
+from cc2olx import filesystem
+
+logger = logging.getLogger()
+
+
+class ModuleMeta:
+    def __init__(self, path):
+        logger.info("Initializing module meta for Canvas flavored CC.")
+        self.tree = filesystem.get_xml_tree(path)
+        self.root = self.tree.getroot()
+        self._init_modules()
+        self._init_items()
+
+    def _init_modules(self):
+        """
+        Extract all the <module> tags from module_meta
+        """
+        modules = {}
+        for module in self.root.findall("module"):
+            if module.attrib.get("identifier"):
+                modules[module.attrib.get("identifier")] = module
+        self.modules = modules
+
+    def _init_items(self):
+        """
+        Extract all the <item> from modules
+        """
+        module_items = {}
+        items = self.root.findall(".//{*}item")
+        for item in items:
+            if item.attrib.get("identifier"):
+                module_items[item.attrib["identifier"]] = {
+                    "title": getattr(item.find("./{*}title"), "text", None),
+                    "content_type": item.find("./{*}content_type").text,
+                    "identifierref": getattr(item.find("./{*}identifierref"), "text", None),
+                    # ContextExternalTool type has url property
+                    "url": getattr(item.find("./{*}url"), "text", None),
+                }
+        self.items = module_items
+
+    def _get_item_data(self, identifier, content_type):
+        """
+        Returns the item data if item exists and the content_type
+        matches given content_type.
+        """
+        item = self.items.get(identifier)
+        if item and item["content_type"] == content_type:
+            return item
+
+    def get_external_tool_item_data(self, identifier):
+        """
+        Returns the item data if item exists and content_type is
+        ContextExternalTool
+        """
+        return self._get_item_data(identifier, "ContextExternalTool")
+
+    def get_item_by_id(self, identifier):
+        """
+        Get a module item given the identifier.
+        """
+        return self.items.get(identifier)
+
+    def get_identifierref(self, identifier):
+        """
+        Get a item identifierref from identifier.
+        """
+        return self.items.get(identifier, {}).get("identifierref")
+
+    def get_module_by_id(self, identifier):
+        """
+        Get a module from module identifier
+        """
+        return self.modules.get("identifier")

--- a/src/cc2olx/main.py
+++ b/src/cc2olx/main.py
@@ -12,14 +12,14 @@ from cc2olx.models import Cartridge, OLX_STATIC_DIR
 from cc2olx.settings import collect_settings
 
 
-def convert_one_file(input_file, workspace, link_file=None):
+def convert_one_file(input_file, workspace, link_file=None, passport_file=None):
     filesystem.create_directory(workspace)
 
     cartridge = Cartridge(input_file, workspace)
     cartridge.load_manifest_extracted()
     cartridge.normalize()
 
-    olx_export = olx.OlxExport(cartridge, link_file)
+    olx_export = olx.OlxExport(cartridge, link_file, passport_file)
     olx_filename = cartridge.directory.parent / (cartridge.directory.name + "-course.xml")
     policy_filename = cartridge.directory.parent / "policy.json"
 
@@ -52,6 +52,7 @@ def main():
 
     workspace = settings["workspace"]
     link_file = settings["link_file"]
+    passport_file = settings["passport_file"]
 
     # setup logger
     logging_config = settings["logging_config"]
@@ -63,7 +64,7 @@ def main():
 
         for input_file in settings["input_files"]:
             try:
-                convert_one_file(input_file, temp_workspace, link_file)
+                convert_one_file(input_file, temp_workspace, link_file, passport_file)
             except Exception:
                 logger.exception("Error while converting %s file", input_file)
 

--- a/src/cc2olx/models.py
+++ b/src/cc2olx/models.py
@@ -9,6 +9,8 @@ from cc2olx import filesystem
 from cc2olx.external.canvas import ModuleMeta
 from cc2olx.qti import QtiParser
 
+from .utils import simple_slug
+
 logger = logging.getLogger()
 
 MANIFEST = "imsmanifest.xml"
@@ -741,6 +743,13 @@ class Cartridge:
             parameters = dict()
         else:
             parameters = {option.get("name"): option.text for option in custom}
+        # For Canvas flavored CC, tool_id can be used as lti_id if present
+        tool_id = root.find("blti:extensions/lticm:property[@name='tool_id']", ns)
+        if tool_id is None:
+            # Create a simple slug lti_id from title
+            lti_id = simple_slug(title)
+        else:
+            lti_id = tool_id.text
         data = {
             "title": title,
             "description": description,
@@ -748,6 +757,7 @@ class Cartridge:
             "height": height,
             "width": width,
             "custom_parameters": parameters,
+            "lti_id": lti_id,
         }
         return data
 

--- a/src/cc2olx/models.py
+++ b/src/cc2olx/models.py
@@ -6,6 +6,7 @@ from textwrap import dedent
 import zipfile
 
 from cc2olx import filesystem
+from cc2olx.external.canvas import ModuleMeta
 from cc2olx.qti import QtiParser
 
 logger = logging.getLogger()
@@ -114,7 +115,7 @@ class Cartridge:
                     # process each child recusively
                     child = collapse_sub_headers(child)
 
-                    meta = self.module_meta.get(child.get("identifier"))
+                    meta = self.module_meta.get_item_by_id(child.get("identifier"))
                     if meta and meta.get("content_type") == "ContextModuleSubHeader":
                         # if there is a sub header, track it
                         collapse_to = child
@@ -318,6 +319,8 @@ class Cartridge:
 
         """
         res = self.resources_by_id.get(identifier)
+        if res is None and self.is_canvas_flavor:
+            res = self.resources_by_id.get(self.module_meta.get_identifierref(identifier))
         if res is None:
             logger.info("Missing resource: %s", identifier)
             return None, None
@@ -376,6 +379,11 @@ class Cartridge:
         # Match any of imsbasiclti_xmlv1p0, imsbasiclti_xmlv1p3 etc
         elif re.match(r"^imsbasiclti_xmlv\d+p\d+$", res_type):
             data = self._parse_lti(res)
+            # Canvas flavored courses have correct url in module meta for lti links
+            if self.is_canvas_flavor:
+                item_data = self.module_meta.get_external_tool_item_data(identifier)
+                if item_data:
+                    data["launch_url"] = item_data.get("url", data["launch_url"])
             return "lti", data
 
         # Match any of imsqti_xmlv1p2/imscc_xmlv1p1/assessment, imsqti_xmlv1p3/imscc_xmlv1p3/assessment etc
@@ -492,16 +500,7 @@ class Cartridge:
         Load module meta from course settings if exists
         """
         module_meta_path = self.directory / COURSE_SETTINGS_DIR / MODULE_META
-        tree = filesystem.get_xml_tree(module_meta_path)
-        module_meta = {}
-        if tree:
-            root = tree.getroot()
-            items = root.findall(".//{*}item")
-            for item in items:
-                if item.attrib.get("identifier"):
-                    module_meta[item.attrib["identifier"]] = {
-                        "content_type": item.find("./{*}content_type").text,
-                    }
+        module_meta = ModuleMeta(module_meta_path)
         return module_meta
 
     def _update_namespaces(self, root):

--- a/src/cc2olx/olx.py
+++ b/src/cc2olx/olx.py
@@ -208,11 +208,22 @@ class OlxExport:
             html = html.replace(item, new_item)
             return html
 
+        def process_external_tools_link(item, html):
+            """
+            Replace $CANVAS_OBJECT_REFERENCE$/external_tools/retrieve with appropriate external link
+            """
+            external_tool_query = urllib.parse.urlparse(item).query
+            external_tool_url = urllib.parse.parse_qs(external_tool_query).get("url", [""])[0]
+            html = html.replace(item, external_tool_url)
+            return html
+
         for _, item in items:
             if "IMS-CC-FILEBASE" in item:
                 html = process_ims_cc_filebase(item, html)
             elif "WIKI_REFERENCE" in item:
                 html = process_wiki_reference(item, html)
+            elif "external_tools" in item:
+                html = process_external_tools_link(item, html)
             elif "CANVAS_OBJECT_REFERENCE" in item:
                 html = process_canvas_reference(item, html)
 

--- a/src/cc2olx/settings.py
+++ b/src/cc2olx/settings.py
@@ -46,5 +46,6 @@ def collect_settings(parsed_args):
         "logging_config": logging_config,
         "workspace": Path.cwd() / "output",
         "link_file": parsed_args.link_file,
+        "passport_file": parsed_args.passport_file,
     }
     return settings

--- a/src/cc2olx/utils.py
+++ b/src/cc2olx/utils.py
@@ -1,6 +1,7 @@
 """ Utility functions for cc2olx"""
 import logging
 import string
+import csv
 
 logger = logging.getLogger()
 
@@ -53,3 +54,38 @@ def simple_slug(value: str):
     char_to_convert = string.punctuation + " "
     slug = "".join(char if char not in char_to_convert else "_" for char in value)
     return slug.replace("__", "_").strip("_").lower()
+
+
+def passport_file_parser(filename: str):
+    """
+    Reads and parse passport file.
+
+    Args:
+        filename (str) - path of the file containing lti consumer details
+
+    Returns:
+        passports (dict) - Dictionary with lti consumer id and corresponding passports
+    """
+    required_fields = ["consumer_id", "consumer_key", "consumer_secret"]
+    with open(filename, "r", encoding="utf-8") as csvfile:
+        passport_file = csv.DictReader(csvfile)
+
+        # Validation: File should contain the required headers.
+        headers = passport_file.fieldnames or []
+        fields_in_header = [field in headers for field in required_fields]
+        if not all(fields_in_header):
+            logger.warning(
+                "Ignoring passport file (%s). Please ensure that the file"
+                " contains required headers consumer_id, consumer_key and consumer_secret.",
+                filename,
+            )
+            return {}
+
+        passports = dict()
+        for row in passport_file:
+            passport = "{lti_id}:{key}:{secret}".format(
+                lti_id=row["consumer_id"], key=row["consumer_key"], secret=row["consumer_secret"]
+            )
+            passports[row["consumer_id"]] = passport
+
+        return passports

--- a/src/cc2olx/utils.py
+++ b/src/cc2olx/utils.py
@@ -1,5 +1,6 @@
 """ Utility functions for cc2olx"""
 import logging
+import string
 
 logger = logging.getLogger()
 
@@ -46,3 +47,9 @@ def element_builder(xml_doc):
         return elem
 
     return element
+
+
+def simple_slug(value: str):
+    char_to_convert = string.punctuation + " "
+    slug = "".join(char if char not in char_to_convert else "_" for char in value)
+    return slug.replace("__", "_").strip("_").lower()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,3 +187,35 @@ def iframe_content(fixtures_data_dir):
     with open(html_file_path, "r") as htmlcontent:
         content = htmlcontent.read()
     return content
+
+
+@pytest.fixture(scope="session")
+def passports_csv(fixtures_data_dir):
+    """
+    This fixture helps to provide a valid passports csv file containing all the
+    required headers.
+
+    Args:
+        fixtures_data_dir ([str]): Path to the directory where fixture data is present.
+
+    Returns:
+        [str]: Path to the csv
+    """
+    passports_file_path = str(fixtures_data_dir / "passports.csv")
+    return passports_file_path
+
+
+@pytest.fixture(scope="session")
+def bad_passports_csv(fixtures_data_dir):
+    """
+    This fixture helps to provide a valid passports csv file which does not contain
+    all the required headers.
+
+    Args:
+        fixtures_data_dir ([str]): Path to the directory where fixture data is present.
+
+    Returns:
+        [str]: Path to the csv
+    """
+    bad_passports_csv = str(fixtures_data_dir / "bad_passports.csv")
+    return bad_passports_csv

--- a/tests/fixtures_data/bad_passports.csv
+++ b/tests/fixtures_data/bad_passports.csv
@@ -1,0 +1,2 @@
+consumer_id,consumer_key,bad_consumer_secret_key
+lti_consumer_id,lti_consumer_key,lti_consumer_secret

--- a/tests/fixtures_data/imscc_file/course_settings/module_meta.xml
+++ b/tests/fixtures_data/imscc_file/course_settings/module_meta.xml
@@ -87,6 +87,25 @@
                 <new_tab/>
                 <indent>0</indent>
             </item>
+            <item identifier="external_tool">
+                <content_type>ContextExternalTool</content_type>
+                <workflow_state>active</workflow_state>
+                <title>External Tool</title>
+                <identifierref>resource_external_lti_tool</identifierref>
+                <url>https://example.com/lit/launch/content_id</url>
+                <position>6</position>
+                <new_tab>true</new_tab>
+                <indent>1</indent>
+            </item>
+            <item identifier="external_tool_retrieve">
+                <content_type>WikiPage</content_type>
+                <workflow_state>active</workflow_state>
+                <title>External Tool Retrieve Iframe</title>
+                <identifierref>resource_external_tool_retrieve</identifierref>
+                <position>7</position>
+                <new_tab>true</new_tab>
+                <indent>0</indent>
+            </item>
         </items>
     </module>
 </modules>

--- a/tests/fixtures_data/imscc_file/imsmanifest.xml
+++ b/tests/fixtures_data/imscc_file/imsmanifest.xml
@@ -87,6 +87,12 @@
                     <item identifier="subheader2_vertical" identifierref="resource_3_vertical">
                         <title>Vertical</title>
                     </item>
+                    <item identifier="external_tool" identifierref="external_tool">
+                        <title>External Tool</title>
+                    </item>
+                    <item identifier="external_tool_retrieve" identifierref="resource_external_tool_retrieve">
+                        <title>External Tool Retrieve Iframe</title>
+                    </item>
                 </item>
             </item>
         </organization>
@@ -148,6 +154,12 @@
         </resource>
         <resource identifier="resource_8_web_link_content" type="imswl_xmlv1p3">
             <file href="web_link_content.xml"/>
+        </resource>
+        <resource identifier="resource_external_lti_tool" type="imsbasiclti_xmlv1p0">
+            <file href="resource_external_lti_tool.xml"/>
+        </resource>
+        <resource identifier="resource_external_tool_retrieve" type="webcontent" href="wiki_content/external_tool_retrieve">
+            <file href="wiki_content/external_tool_retrieve.html"/>
         </resource>
     </resources>
 </manifest>

--- a/tests/fixtures_data/imscc_file/resource_external_lti_tool.xml
+++ b/tests/fixtures_data/imscc_file/resource_external_lti_tool.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cartridge_basiclti_link xmlns="http://www.imsglobal.org/xsd/imslticc_v1p0" xmlns:blti="http://www.imsglobal.org/xsd/imsbasiclti_v1p0" xmlns:lticm="http://www.imsglobal.org/xsd/imslticm_v1p0" xmlns:lticp="http://www.imsglobal.org/xsd/imslticp_v1p0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imslticc_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticc_v1p0.xsd&#10;                          http://www.imsglobal.org/xsd/imsbasiclti_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imsbasiclti_v1p0p1.xsd&#10;                          http://www.imsglobal.org/xsd/imslticm_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticm_v1p0.xsd&#10;                          http://www.imsglobal.org/xsd/imslticp_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticp_v1p0.xsd">
+    <blti:title>External Tool LTI</blti:title>
+    <blti:description>Canvas External Tool Basic LTI link. Here the link is different from link in secure_launch_url</blti:description>
+    <blti:secure_launch_url>https://example.com/lit/launch</blti:secure_launch_url>
+    <blti:vendor>
+        <lticp:code>unknown</lticp:code>
+        <lticp:name>unknown</lticp:name>
+    </blti:vendor>
+    <blti:custom>
+    </blti:custom>
+    <blti:extensions platform="canvas.instructure.com">
+    </blti:extensions>
+</cartridge_basiclti_link>

--- a/tests/fixtures_data/imscc_file/wiki_content/external_tool_retrieve.html
+++ b/tests/fixtures_data/imscc_file/wiki_content/external_tool_retrieve.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<title>External Tool Retrieve Content</title>
+<meta name="identifier" content="resource_external_tool_retrieve"/>
+<meta name="editing_roles" content="teachers"/>
+<meta name="workflow_state" content="active"/>
+</head>
+<body>
+<p>
+<iframe
+src="%24CANVAS_COURSE_REFERENCE%24/external_tools/retrieve?display=borderless&amp;url=https%3A%2F%2Fexample.com%2Flti-retrieve"
+width="608"
+height="402"
+allow="autoplay *">
+</iframe>
+</p>
+</body>
+</html>

--- a/tests/fixtures_data/passports.csv
+++ b/tests/fixtures_data/passports.csv
@@ -1,0 +1,4 @@
+consumer_id,consumer_key,consumer_secret
+codio,my_codio_key,my_codio_secret
+lti_tool,my_consumer_key,my_consumer_secret_key
+external_tool_lti,external_tool_lti_key,external_tool_lti_secret

--- a/tests/fixtures_data/studio_course_xml/course.xml
+++ b/tests/fixtures_data/studio_course_xml/course.xml
@@ -279,6 +279,38 @@
 </html>
 ]]></html>
 			</vertical>
+			<vertical display_name="External Tool" url_name="">
+				<lti_consumer custom_parameters="[]"
+					description="Canvas External Tool Basic LTI link. Here the link is different from link in secure_launch_url"
+					display_name="External Tool" inline_height="500" inline_width="500"
+					launch_url="https://example.com/lit/launch/content_id"
+					modal_height="500"
+					modal_width="500"
+					url_name="external_tool"
+					xblock-family="xblock.v1"/>
+			</vertical>
+			<vertical display_name="External Tool Retrieve Iframe" url_name="">
+			<html display_name="External Tool Retrieve Iframe" url_name="resource_external_tool_retrieve"><![CDATA[<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<title>External Tool Retrieve Content</title>
+<meta name="identifier" content="resource_external_tool_retrieve"/>
+<meta name="editing_roles" content="teachers"/>
+<meta name="workflow_state" content="active"/>
+</head>
+<body>
+<p>
+<iframe
+src="https://example.com/lti-retrieve"
+width="608"
+height="402"
+allow="autoplay *">
+</iframe>
+</p>
+</body>
+</html>
+]]></html>
+			</vertical>
 		</sequential>
 	</chapter>
 </course>

--- a/tests/fixtures_data/studio_course_xml/course.xml
+++ b/tests/fixtures_data/studio_course_xml/course.xml
@@ -20,7 +20,7 @@
 ]]></html>
 			</vertical>
 			<vertical display_name="LTI" url_name="">
-				<lti_consumer custom_parameters="[]" description="https://www.imsglobal.org/activity/learning-tools-interoperability" display_name="LTI" inline_height="500" inline_width="500" launch_url="https://lti.local/launch" modal_height="500" modal_width="500" xblock-family="xblock.v1" url_name="resource_2_lti"/>
+				<lti_consumer custom_parameters="[]" description="https://www.imsglobal.org/activity/learning-tools-interoperability" display_name="LTI" inline_height="500" inline_width="500" launch_url="https://lti.local/launch" modal_height="500" modal_width="500" xblock-family="xblock.v1" url_name="resource_2_lti" lti_id="learning_tools_interoperability"/>
 			</vertical>
 			<vertical display_name="QTI" url_name="">
 				<problem display_name="QTI" url_name="resource_4_qti">
@@ -287,6 +287,7 @@
 					modal_height="500"
 					modal_width="500"
 					url_name="external_tool"
+					lti_id="external_tool_lti"
 					xblock-family="xblock.v1"/>
 			</vertical>
 			<vertical display_name="External Tool Retrieve Iframe" url_name="">

--- a/tests/test_canvas_module_meta.py
+++ b/tests/test_canvas_module_meta.py
@@ -1,0 +1,23 @@
+import pytest
+
+from cc2olx.external.canvas import ModuleMeta
+
+
+@pytest.fixture(scope="session")
+def module_meta(fixtures_data_dir):
+    """
+    Fixture for ModuleMeta object
+    """
+    module_meta_path = fixtures_data_dir / "imscc_file" / "course_settings" / "module_meta.xml"
+    module_meta = ModuleMeta(module_meta_path)
+    return module_meta
+
+
+def test_external_tool_data_has_url(module_meta):
+    """
+    Tests that external tool data contains url
+    """
+    expected = "https://example.com/lit/launch/content_id"
+    data = module_meta.get_external_tool_item_data("external_tool")
+    actual = data["url"]
+    assert expected == actual

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,9 @@ def test_parse_args(imscc_file):
         ]
     )
 
-    assert parsed_args == Namespace(inputs=[imscc_file], loglevel="INFO", result="folder", link_file=None)
+    assert parsed_args == Namespace(
+        inputs=[imscc_file], loglevel="INFO", result="folder", link_file=None, passport_file=None
+    )
 
 
 def test_parse_args_csv_file(imscc_file, link_map_csv):
@@ -25,4 +27,16 @@ def test_parse_args_csv_file(imscc_file, link_map_csv):
 
     parsed_args = parse_args(["-i", str(imscc_file), "-f", link_map_csv])
 
-    assert parsed_args == Namespace(inputs=[imscc_file], loglevel="INFO", result="folder", link_file=link_map_csv)
+    assert parsed_args == Namespace(
+        inputs=[imscc_file], loglevel="INFO", result="folder", link_file=link_map_csv, passport_file=None
+    )
+
+
+def test_parse_args_passport_file(imscc_file, passports_csv):
+    """
+    Input test for lti passport csv
+    """
+    parsed_args = parse_args(["-i", str(imscc_file), "-p", passports_csv])
+    assert parsed_args == Namespace(
+        inputs=[imscc_file], loglevel="INFO", result="folder", link_file=None, passport_file=passports_csv
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -37,7 +37,7 @@ def test_load_manifest_extracted(imscc_file, settings, temp_workspace_dir):
         "version": cartridge_version,
     }
 
-    assert len(cartridge.resources) == 14
+    assert len(cartridge.resources) == 16
     assert len(cartridge.resources[0]["children"]) == 6
     assert isinstance(cartridge.resources[0]["children"][0], ResourceFile)
 
@@ -248,7 +248,31 @@ def test_cartridge_normalize(imscc_file, settings):
                                 "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
                                 "identifierref": None,
                                 "title": "Vertical",
-                            }
+                            },
+                            {
+                                "children": [
+                                    {
+                                        "identifier": "external_tool",
+                                        "identifierref": "external_tool",
+                                        "title": "External Tool",
+                                    }
+                                ],
+                                "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                                "identifierref": None,
+                                "title": "External Tool",
+                            },
+                            {
+                                "children": [
+                                    {
+                                        "identifier": "external_tool_retrieve",
+                                        "identifierref": "resource_external_tool_retrieve",
+                                        "title": "External Tool Retrieve Iframe",
+                                    }
+                                ],
+                                "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                                "identifierref": None,
+                                "title": "External Tool Retrieve Iframe",
+                            },
                         ],
                         "identifier": "subheader2",
                         "identifierref": None,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -307,6 +307,7 @@ def test_cartridge_get_resource_content(cartridge):
             "height": "500",
             "width": "500",
             "custom_parameters": {},
+            "lti_id": "learning_tools_interoperability",
         },
     )
 

--- a/tests/test_olx.py
+++ b/tests/test_olx.py
@@ -97,3 +97,47 @@ class TestOlXExporeterIframeParser:
         nodes = olx_exporter._create_olx_nodes("html", {"html": iframe_content})
         # Html xblock and video xblock
         assert len(nodes) == 2
+
+
+class TestOlxExporterLtiPolicy:
+    def _get_oxl_exporter(self, cartridge, passports_csv):
+        """
+        Helper function to create olx exporter.
+
+        Args:
+            cartridge ([Cartridge]): Cartridge class instance.
+            link_map_csv ([str]): Csv file path.
+
+        Returns:
+            [OlxExport]: OlxExport instance.
+        """
+        olx_exporter = olx.OlxExport(cartridge, passport_file=passports_csv)
+        olx_exporter.doc = xml.dom.minidom.Document()
+        return olx_exporter
+
+    def test_lti_consumer_present_set_to_true(self, cartridge, passports_csv):
+        olx_exporter = self._get_oxl_exporter(cartridge, passports_csv)
+        _ = olx_exporter.xml()
+
+        assert olx_exporter.lti_consumer_present is True
+        assert olx_exporter.lti_consumer_ids == {"external_tool_lti", "learning_tools_interoperability"}
+
+    def test_policy_contains_advanced_module(self, cartridge, passports_csv, caplog):
+        olx_exporter = self._get_oxl_exporter(cartridge, passports_csv)
+        _ = olx_exporter.xml()
+        caplog.clear()
+        policy = json.loads(olx_exporter.policy())
+
+        assert policy["course/course"]["advanced_modules"] == ["lti_consumer"]
+        # Converting to set because the order might change
+        assert set(policy["course/course"]["lti_passports"]) == {
+            "codio:my_codio_key:my_codio_secret",
+            "lti_tool:my_consumer_key:my_consumer_secret_key",
+            "external_tool_lti:external_tool_lti_key:external_tool_lti_secret",
+            "learning_tools_interoperability:consumer_key:consumer_secret",
+        }
+
+        # Warning for missing LTI passort is logged
+        assert ["Missing LTI Passport for learning_tools_interoperability. Using default."] == [
+            rec.message for rec in caplog.records
+        ]

--- a/tests/test_passport_file_parser.py
+++ b/tests/test_passport_file_parser.py
@@ -1,0 +1,24 @@
+from cc2olx.utils import passport_file_parser
+
+
+def test_parser_warns_on_missing_header(bad_passports_csv, caplog):
+    passports = passport_file_parser(bad_passports_csv)
+
+    assert [rec.levelname for rec in caplog.records] == ["WARNING"]
+    assert [rec.message for rec in caplog.records] == [
+        "Ignoring passport file (%s). Please ensure that the file"
+        " contains required headers consumer_id, consumer_key and consumer_secret." % bad_passports_csv
+    ]
+    assert passports == {}
+
+
+def test_parser_returns_correct_dict(passports_csv, caplog):
+    passports = passport_file_parser(passports_csv)
+
+    # assert there are no warning logs
+    assert [rec.message for rec in caplog.records] == []
+    assert passports == {
+        "codio": "codio:my_codio_key:my_codio_secret",
+        "lti_tool": "lti_tool:my_consumer_key:my_consumer_secret_key",
+        "external_tool_lti": "external_tool_lti:external_tool_lti_key:external_tool_lti_secret",
+    }

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -14,6 +14,7 @@ def test_collect_settings(imscc_file):
         "output_format": parsed_args.result,
         "workspace": Path.cwd() / "output",
         "link_file": None,
+        "passport_file": None,
         "logging_config": {
             "level": parsed_args.loglevel,
             "format": "{%(filename)s:%(lineno)d} - %(message)s",


### PR DESCRIPTION
Adds module meta parser and handler for external_tools
links for canvas flavoured CC. Also adds a parameter `----passport-file` to add LTI passports in `policy.json`

## Related Tickets
1. [TNL-8046](https://openedx.atlassian.net/browse/TNL-8046)
2. [BB-3973](https://tasks.opencraft.com/browse/BB-3973)

## Testing Instructions

#### Testing Canvas External Tools Support

1. On master branch, Run cc2olx on a Canvas CC with external tools
2. Import the converted course in studio
3. Verify that the external tools content is converted to `MISSING CONTENT`
4. Checkout to this branch.
5. Convert the same Canvas CC course again.
6. Import the new converted course in studio
7. Verify that the external tools content is now visible. (LTI link might fail to load because of missing consumer key and secret)

#### Testing --passport-file parameter

1. Checkout to this branch
2. Convert a CC course with LTI components.
3. Verify that `policy.json` has `lti_consumer` in `advanced_modules`
4. Verify that `policy.json` has `lit_passports` with default values for all LTI tools in course.
5. Create a passport csv file with `consumer_id`, `consumer_key` and `consumer_secret` fields
6. Convert the CC course again with `--passport-file [FILE_PATH]` argument.
7. Verify that `policy.json` now has values from passport file in `lti_passports`.

## Reviewers
- [ ] @kaizoku 
- [x] edx-reviewer