### PR TITLE
[BD-27] Initial script for downloading videos

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,3 +2,4 @@
 
 lxml
 requests
+youtube-dl

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,3 +16,5 @@ requests==2.25.1
     # via -r requirements/base.in
 urllib3==1.26.4
     # via requests
+youtube-dl==2021.4.7
+    # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -205,6 +205,8 @@ wheel==0.36.2
     # via -r requirements/dev.in
 xmlformatter==0.2.2
     # via -r requirements/quality.txt
+youtube-dl==2021.4.7
+    # via -r requirements/quality.txt
 zipp==1.2.0
     # via
     #   -c requirements/constraints.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -88,3 +88,5 @@ urllib3==1.26.4
     #   requests
 xmlformatter==0.2.2
     # via -r requirements/test.txt
+youtube-dl==2021.4.7
+    # via -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -53,3 +53,5 @@ urllib3==1.26.4
     #   requests
 xmlformatter==0.2.2
     # via -r requirements/test.in
+youtube-dl==2021.4.7
+    # via -r requirements/base.txt

--- a/src/cc2olx/tools/video_download.py
+++ b/src/cc2olx/tools/video_download.py
@@ -1,0 +1,175 @@
+import argparse
+import json
+import csv
+import zipfile
+from urllib.parse import parse_qs, urlparse
+
+from lxml import html
+
+import youtube_dl
+
+
+def parse_args(args=None):
+    """Parse command line arguments."""
+
+    parser = argparse.ArgumentParser(description="Find and download videos from a CC course.")
+    parser.add_argument("--config", "-c", help="JSON config file")
+    parser.add_argument("--input", "-i", help="Input CC zip or HTML file", required=True)
+    parser.add_argument("--output", "-o", default="out.csv", help="CSV output file")
+    parser.add_argument("--downloads", "-d", default="downloads", help="Video download directory")
+    parser.add_argument("--simulate", "-s", action="store_true", help="Simulate downloads")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Verbose ytd downloads")
+
+    return parser.parse_args(args)
+
+
+def get_ydl_opts(args):
+    """Set options to be used by Youtube DL"""
+
+    if args.config:
+        return json.load(open(args.config))
+
+    return {
+        "verbose": args.verbose,
+        "simulate": args.simulate,
+        "writesubtitles": True,
+        "writeautomaticsub": True,
+        "outtmpl": f"{args.downloads}/%(title)s.%(ext)s",
+    }
+
+
+def download_videos(urls, opts):
+    """
+    Download a list of videos and optionally transcripts.
+    Arguments:
+        * videos: a list of URLs
+        * opts: options for Youtube DL
+    """
+
+    relpaths = []
+
+    def my_hook(d):
+        """Youtube DL callback"""
+        if d["status"] == "finished":
+            fn = d["filename"]
+            if not fn.endswith("m4a"):
+                relpaths.append(fn)
+
+    opts["progress_hooks"] = [my_hook]
+
+    ydl = youtube_dl.YoutubeDL(opts)
+    ydl.download(urls)
+
+    return relpaths
+
+
+def make_row(relpath, url):
+    """Create an entry for the output CSV."""
+
+    youtube_id = ""
+    if "youtube.com" in url:
+        youtube_id = url.split("=")[-1]
+
+    return {
+        "Relative File Path": relpath,
+        "External Video Link": url,
+        "Youtube Id": youtube_id,
+    }
+
+
+def extract_url(src):
+    """Extract a downloadable video link from a src attribute."""
+    if "youtube.com" in src:
+        url = src.replace("/embed/", "/watch?v=").replace("?rel=0", "")
+        return url
+    elif "cdnapisec.kaltura.com" in src:
+        # Skip playlist URLs
+        if "playlist" in src:
+            return ""
+        return src
+    return ""
+
+
+def find_video_urls(input_html):
+    """Find valid video URLs from iframes in an HTML file."""
+
+    parsed_html = html.parse(input_html)
+    iframes = parsed_html.xpath("//iframe")
+
+    urls = []
+    for iframe in iframes:
+        src = iframe.attrib.get("src", "")
+        url = extract_url(src)
+        if url:
+            urls.append(url)
+    return urls
+
+
+def write_csv(outfile, urls, relpaths):
+    fieldnames = ["Relative File Path", "External Video Link", "Youtube Id"]
+    with open(outfile, "w", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for (r, u) in zip(relpaths, urls):
+            row = make_row(r, u)
+            writer.writerow(row)
+
+
+def get_entry_id(src):
+    """Extract Kaltura entry_id from embedding URL."""
+    entry_id = None
+    parsed_url = urlparse(src)
+    query = parsed_url.query
+    query_dict = parse_qs(query)
+    entry_id_query = query_dict.get("entry_id")
+    if entry_id_query:
+        entry_id = entry_id_query[0]
+    return entry_id
+
+
+def reformat(url):
+    if "kaltura" in url:
+        netloc = url.split("embedIframeJs")[0].strip()
+        entry_id = get_entry_id(url)
+        url = f"{netloc}playManifest/entryId/{entry_id}/format/url/protocol/https"
+
+    return url
+
+
+def find_all_video_urls(name):
+    """
+    Extract video urls from a CC course or HTML file
+    """
+    urls = []
+    if zipfile.is_zipfile(name):
+        with zipfile.ZipFile(name) as z:
+            for filename in z.namelist():
+                if filename.endswith(".html"):
+                    with z.open(filename) as f:
+                        urls += find_video_urls(f)
+    else:
+        # If input is a single HTML for debugging
+        urls += find_video_urls(name)
+
+    return urls
+
+
+def main():
+    args = parse_args()
+    ydl_opts = get_ydl_opts(args)
+
+    urls = find_all_video_urls(args.input)
+    relpaths = download_videos(urls, ydl_opts)
+
+    # Remove download dir prefix from pathnames
+    relpaths = [r.lstrip(f"{args.downloads}/") for r in relpaths]
+
+    # Reformat URLs as expected by the cc2olx tool
+    urls = [reformat(u) for u in urls]
+
+    write_csv(args.output, urls, relpaths)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_video_download_tool.py
+++ b/tests/test_video_download_tool.py
@@ -1,0 +1,162 @@
+from argparse import Namespace
+from unittest.mock import call, Mock
+
+from cc2olx.tools.video_download import (
+    parse_args,
+    find_all_video_urls,
+    reformat,
+    get_ydl_opts,
+    write_csv,
+    main,
+    download_videos,
+)
+
+
+def test_find_video_urls_in_html(fixtures_data_dir):
+    """
+    Basic test for extracting Kaltura URLs.
+    """
+
+    html_file_path = str(fixtures_data_dir / "imscc_file" / "iframe.html")
+    urls = find_all_video_urls(html_file_path)
+    urls = [reformat(u) for u in urls]
+    expected = [
+        "https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_zeqnrfgw/format/url/protocol/https"
+    ]
+    assert urls == expected
+
+
+def test_find_all_video_urls_in_cc(imscc_file):
+    """
+    Basic test for extracting Kaltura URLs.
+    """
+
+    urls = find_all_video_urls(imscc_file)
+    urls = [reformat(u) for u in urls]
+    expected = [
+        "https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_zeqnrfgw/format/url/protocol/https",  # noqa: E501
+        "https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_zeqnrfgw/format/url/protocol/https",  # noqa: E501
+    ]
+    assert urls == expected
+
+
+def test_parse_args(imscc_file):
+    """
+    Basic cli test.
+    """
+
+    parsed_args = parse_args(["-i", str(imscc_file), "-o", "outfile.csv", "-d", "download_dir", "-v"])
+
+    assert parsed_args == Namespace(
+        input=str(imscc_file), config=None, output="outfile.csv", downloads="download_dir", simulate=False, verbose=True
+    )
+
+
+def test_ydl_opts():
+    """
+    Basic test of youtube-dl options.
+    """
+
+    parsed_args = parse_args(["-i", "file.html", "-d", "download_dir", "-v", "-s"])
+    opts = get_ydl_opts(parsed_args)
+
+    assert opts["verbose"]
+    assert opts["simulate"]
+    assert opts["outtmpl"] == "download_dir/%(title)s.%(ext)s"
+
+
+def test_write_csv(mocker):
+    csv_writerow_mock = mocker.patch("csv.DictWriter.writerow")
+
+    urls = ["url1", "url2", "youtube.com/watch?v=1234"]
+    relpaths = ["rel1", "rel2", "rel3"]
+
+    write_csv("outfile", urls, relpaths)
+
+    expected_csv_writerow_call_args = [
+        call(
+            {
+                "Relative File Path": "Relative File Path",
+                "External Video Link": "External Video Link",
+                "Youtube Id": "Youtube Id",
+            }
+        ),
+        call(
+            {
+                "Relative File Path": "rel1",
+                "External Video Link": "url1",
+                "Youtube Id": "",
+            }
+        ),
+        call(
+            {
+                "Relative File Path": "rel2",
+                "External Video Link": "url2",
+                "Youtube Id": "",
+            }
+        ),
+        call(
+            {
+                "Relative File Path": "rel3",
+                "External Video Link": "youtube.com/watch?v=1234",
+                "Youtube Id": "1234",
+            }
+        ),
+    ]
+
+    csv_writerow_mock.assert_has_calls(expected_csv_writerow_call_args, any_order=True)
+
+
+class FakeYDL:
+    def __init__(self, opts):
+        self.opts = opts
+
+    def download(self, urls):
+        for url in urls:
+            for hook in self.opts["progress_hooks"]:
+                hook({"status": "finished", "filename": "filename.mp4"})
+
+
+def test_main(mocker, imscc_file):
+    args_mock = Mock()
+    args_mock.configure_mock(config=None, input=imscc_file, output="outfileXXX", simulate=True)
+    mocker.patch("cc2olx.tools.video_download.parse_args", return_value=args_mock)
+    mocker.patch("cc2olx.tools.video_download.youtube_dl.YoutubeDL", new=FakeYDL)
+
+    csv_writerow_mock = mocker.patch("csv.DictWriter.writerow")
+
+    main()
+
+    expected_csv_writerow_call_args = [
+        call(
+            {
+                "Relative File Path": "Relative File Path",
+                "External Video Link": "External Video Link",
+                "Youtube Id": "Youtube Id",
+            }
+        ),
+        call(
+            {
+                "Relative File Path": "filename.mp4",
+                "External Video Link": "https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_zeqnrfgw/format/url/protocol/https",  # noqa: E501
+                "Youtube Id": "",
+            }
+        ),
+        call(
+            {
+                "Relative File Path": "filename.mp4",
+                "External Video Link": "https://cdnapisec.kaltura.com/p/2019031/sp/201903100/playManifest/entryId/1_zeqnrfgw/format/url/protocol/https",  # noqa: E501
+                "Youtube Id": "",
+            }
+        ),
+    ]
+
+    csv_writerow_mock.assert_has_calls(expected_csv_writerow_call_args, any_order=True)
+
+
+def test_download_videos(mocker):
+    parsed_args = parse_args(["-i", "file.html", "-d", "download_dir", "-v", "-s"])
+    opts = get_ydl_opts(parsed_args)
+    mocker.patch("cc2olx.tools.video_download.youtube_dl.YoutubeDL", return_value=FakeYDL(opts))
+    ret = download_videos(["url1", "url2", "url3"], opts)
+    assert ret == ["filename.mp4", "filename.mp4", "filename.mp4"]


### PR DESCRIPTION
## Description

This script searches for video links in CC courses, downloads them along with transcripts to a local directory and creates a link map csv file to be used with the cc2olx tool.

## Testing instructions

Pass a local .imscc file with Kaltura videos in it to the script and have it download the embedded videos.
The script shows the command line argument it requires.

