### PR TITLE
[BD-27] Allow specifying output folder/zipfile name

### DIFF
--- a/src/cc2olx/cli.py
+++ b/src/cc2olx/cli.py
@@ -43,6 +43,13 @@ def parse_args(args=None):
         ),
     )
     parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        default="output",
+        help=("Optionally provide the name for output folder or zipfile (without the .zip extension)."),
+    )
+    parser.add_argument(
         "-f",
         "--link_file",
         default=None,

--- a/src/cc2olx/settings.py
+++ b/src/cc2olx/settings.py
@@ -44,7 +44,7 @@ def collect_settings(parsed_args):
         "input_files": input_files,
         "output_format": parsed_args.result,
         "logging_config": logging_config,
-        "workspace": Path.cwd() / "output",
+        "workspace": Path.cwd() / parsed_args.output,
         "link_file": parsed_args.link_file,
         "passport_file": parsed_args.passport_file,
     }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ def test_parse_args(imscc_file):
     )
 
     assert parsed_args == Namespace(
-        inputs=[imscc_file], loglevel="INFO", result="folder", link_file=None, passport_file=None
+        inputs=[imscc_file], loglevel="INFO", result="folder", link_file=None, passport_file=None, output="output"
     )
 
 
@@ -28,7 +28,12 @@ def test_parse_args_csv_file(imscc_file, link_map_csv):
     parsed_args = parse_args(["-i", str(imscc_file), "-f", link_map_csv])
 
     assert parsed_args == Namespace(
-        inputs=[imscc_file], loglevel="INFO", result="folder", link_file=link_map_csv, passport_file=None
+        inputs=[imscc_file],
+        loglevel="INFO",
+        result="folder",
+        link_file=link_map_csv,
+        passport_file=None,
+        output="output",
     )
 
 
@@ -38,5 +43,10 @@ def test_parse_args_passport_file(imscc_file, passports_csv):
     """
     parsed_args = parse_args(["-i", str(imscc_file), "-p", passports_csv])
     assert parsed_args == Namespace(
-        inputs=[imscc_file], loglevel="INFO", result="folder", link_file=None, passport_file=passports_csv
+        inputs=[imscc_file],
+        loglevel="INFO",
+        result="folder",
+        link_file=None,
+        passport_file=passports_csv,
+        output="output",
     )


### PR DESCRIPTION
## Description

This allows specifying a different name for the output directory or zipfile which is now hardcoded to 'output'
It is helpful when trying the tool on various courses during development