### PR TITLE
[BD-27] Return a list from _create_video_node.

### DIFF
--- a/src/cc2olx/olx.py
+++ b/src/cc2olx/olx.py
@@ -338,7 +338,7 @@ class OlxExport:
         xml_element = element_builder(self.doc)
         attributes = {"youtube": "1.00:" + details["youtube"], "youtube_id_1_0": details["youtube"]}
         child = xml_element("video", children=None, attributes=attributes)
-        return child
+        return [child]
 
     def _process_html(self, details):
         """


### PR DESCRIPTION
The return value needs to be a list, otherwise an error is thrown.

Testing:
cc2olx -i test_data/ushistory.imscc
