### PR TITLE
fix: if resource content is empty, replace with html

### DIFF
--- a/src/cc2olx/olx.py
+++ b/src/cc2olx/olx.py
@@ -182,7 +182,7 @@ class OlxExport:
             idref = element_data["identifierref"]
             content_type, details = self.cartridge.get_resource_content(idref)
 
-        if content_type is None:
+        if content_type is None or not details:
             content_type = self.HTML
             details = {
                 "html": "<p>MISSING CONTENT</p>",

--- a/tests/fixtures_data/imscc_file/course_settings/module_meta.xml
+++ b/tests/fixtures_data/imscc_file/course_settings/module_meta.xml
@@ -35,6 +35,15 @@
                 <new_tab/>
                 <indent>0</indent>
             </item>
+            <item identifier="qti_no_items">
+                <content_type>Quizzes::Quiz</content_type>
+                <workflow_state>active</workflow_state>
+                <title>QTI</title>
+                <identifierref></identifierref>
+                <position>2</position>
+                <new_tab/>
+                <indent>0</indent>
+            </item>
         </items>
     </module>
     <module identifier="sequence2">

--- a/tests/fixtures_data/imscc_file/imsmanifest.xml
+++ b/tests/fixtures_data/imscc_file/imsmanifest.xml
@@ -45,6 +45,9 @@
                     <item identifier="qti" identifierref="resource_4_qti">
                         <title>QTI</title>
                     </item>
+                    <item identifier="qti_no_items" identifierref="resource_4_qti_no_items">
+                        <title>QTI No Items</title>
+                    </item>
                     <item identifier="discussion_topic_item" identifierref="discussion_topic">
                         <title>Discussion</title>
                     </item>
@@ -130,6 +133,9 @@
         <resource identifier="resource_5_qti_dependency" type="associatedcontent/imscc_xmlv1p1/learning-application-resource" href="resource_4_qti/assessment_meta.xml">
             <file href="resource_4_qti/assessment_meta.xml"/>
             <file href="non_cc_assessments/resource_4_qti.xml.qti"/>
+        </resource>
+        <resource identifier="resource_4_qti_no_items" type="imsqti_xmlv1p2/imscc_xmlv1p1/assessment">
+            <file href="resource_4_qti_no_items/assessment_qti.xml"/>
         </resource>
         <resource identifier="discussion_topic" type="imsdt_xmlv1p1">
             <file href="discussion_topic.xml" />

--- a/tests/fixtures_data/imscc_file/resource_4_qti_no_items/assessment_meta.xml
+++ b/tests/fixtures_data/imscc_file/resource_4_qti_no_items/assessment_meta.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<quiz identifier="resource_4_qti_no_items" xmlns="http://canvas.instructure.com/xsd/cccv1p0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://canvas.instructure.com/xsd/cccv1p0 https://canvas.instructure.com/xsd/cccv1p0.xsd">
+    <title>QTI No Items</title>
+    <description>Description</description>
+    <shuffle_answers>false</shuffle_answers>
+    <scoring_policy>keep_highest</scoring_policy>
+    <hide_results></hide_results>
+    <quiz_type>practice_quiz</quiz_type>
+    <points_possible>0.0</points_possible>
+    <require_lockdown_browser>false</require_lockdown_browser>
+    <require_lockdown_browser_for_results>false</require_lockdown_browser_for_results>
+    <require_lockdown_browser_monitor>false</require_lockdown_browser_monitor>
+    <lockdown_browser_monitor_data/>
+    <show_correct_answers>true</show_correct_answers>
+    <anonymous_submissions>false</anonymous_submissions>
+    <could_be_locked>true</could_be_locked>
+    <disable_timer_autosubmission>false</disable_timer_autosubmission>
+    <allowed_attempts>1</allowed_attempts>
+    <one_question_at_a_time>false</one_question_at_a_time>
+    <cant_go_back>false</cant_go_back>
+    <available>false</available>
+    <one_time_results>false</one_time_results>
+    <show_correct_answers_last_attempt>false</show_correct_answers_last_attempt>
+    <only_visible_to_overrides>false</only_visible_to_overrides>
+    <module_locked>false</module_locked>
+    <assignment_group_identifierref>assignment_group_1</assignment_group_identifierref>
+    <assignment_overrides>
+    </assignment_overrides>
+</quiz>

--- a/tests/fixtures_data/imscc_file/resource_4_qti_no_items/assessment_qti.xml
+++ b/tests/fixtures_data/imscc_file/resource_4_qti_no_items/assessment_qti.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/profile/cc/ccv1p1/ccv1p1_qtiasiv1p2p1_v1p0.xsd">
+    <assessment ident="resource_4_qti_no_items" title="QTI No Items">
+        <qtimetadata>
+            <qtimetadatafield>
+                <fieldlabel>cc_profile</fieldlabel>
+                <fieldentry>cc.exam.v0p1</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+                <fieldlabel>qmd_assessmenttype</fieldlabel>
+                <fieldentry>Examination</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+                <fieldlabel>qmd_scoretype</fieldlabel>
+                <fieldentry>Percentage</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+                <fieldlabel>cc_maxattempts</fieldlabel>
+                <fieldentry>1</fieldentry>
+            </qtimetadatafield>
+        </qtimetadata>
+        <section ident="root_section">
+        </section>
+    </assessment>
+</questestinterop>

--- a/tests/fixtures_data/studio_course_xml/course.xml
+++ b/tests/fixtures_data/studio_course_xml/course.xml
@@ -138,6 +138,9 @@
 					</rubric>
 				</openassessment>
 			</vertical>
+			<vertical display_name="QTI No Items" url_name="">
+                <html display_name="QTI No Items" url_name="resource_4_qti_no_items"><![CDATA[<p>MISSING CONTENT</p>]]></html>
+            </vertical>
 			<vertical display_name="Discussion" url_name="">
 				<html display_name="Discussion" url_name="discussion_topic"><![CDATA[<p style="text-align: center;"><span style="color: #000080; font-size: 18pt;">Math Journal</span><br>Is 70 thousand written in standard form or<br>word form? Explain.</p>]]></html>
 				<discussion display_name="Discussion" discussion_category="Discussion Topic" discussion_target="Discussion Topic" url_name="discussion_topic"/>

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -37,7 +37,7 @@ def test_load_manifest_extracted(imscc_file, settings, temp_workspace_dir):
         "version": cartridge_version,
     }
 
-    assert len(cartridge.resources) == 16
+    assert len(cartridge.resources) == 17
     assert len(cartridge.resources[0]["children"]) == 6
     assert isinstance(cartridge.resources[0]["children"][0], ResourceFile)
 
@@ -88,6 +88,18 @@ def test_cartridge_normalize(imscc_file, settings):
                                 "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
                                 "identifierref": None,
                                 "title": "QTI",
+                            },
+                            {
+                                "children": [
+                                    {
+                                        "identifier": "qti_no_items",
+                                        "identifierref": "resource_4_qti_no_items",
+                                        "title": "QTI No Items",
+                                    }
+                                ],
+                                "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                                "identifierref": None,
+                                "title": "QTI No Items",
                             },
                             {
                                 "children": [


### PR DESCRIPTION
Background: 
A course that was created by using the cc2olx tool was failing on import to Studio due to the following validation error: 
`1. ERROR InvalidPointer (course.xml): The <vertical display_name='xxx '> tag looks like it's trying to be a pointer but contains other attributes.`

The tags where the validation failed were childless verticals that also contained a `url_name` attribute - apparently this kind of tag without children should not contain any additional attributes.

The verticals that caused the validation errors should have had children with a qti content type (as observed in the .imscc file), however the assessments did not contain any problems. This caused any calls to `get_resource_content`, which is used to create the olx for the resource, to return the tuple ('qti', []), where `qti` is the content type and the empty list is representative of the details. Because there were no details returned, no child was added to the vertical. With no child and the additional `url_name` attribute, we get validation errors. My proposed solution is to replace the content-less qti with an HTML node containing a `MISSING CONTENT` message.